### PR TITLE
fix bug that DNS config is not set correctly in ovpngen.sh

### DIFF
--- a/vpn/VpnManager.js
+++ b/vpn/VpnManager.js
@@ -159,7 +159,7 @@ module.exports = class {
                     // !! Pay attention to the parameter "-E" which is used to preserve the
                     // enviornment valueables when running sudo commands
                     
-                    let mydns = sysManager.myDNS()[0]; 
+                    var mydns = sysManager.myDNS()[0]; 
                     if (mydns == null) {
                         mydns = "8.8.8.8"; // use google DNS as default
                     }
@@ -294,7 +294,13 @@ module.exports = class {
             if (ip == null) {
                 ip = sysManager.publicIp;
             }
-            let cmd = util.format("cd %s/vpn; sudo -E ./ovpngen.sh %s %s %s %s; sync", fHome, clientname, password, sysManager.myIp(), ip);
+
+            var mydns = sysManager.myDNS()[0]; 
+            if (mydns == null) {
+                mydns = "8.8.8.8"; // use google DNS as default
+            }
+            
+            let cmd = util.format("cd %s/vpn; sudo -E ./ovpngen.sh %s %s %s %s %s; sync", fHome, clientname, password, sysManager.myIp(), ip, mydns);
             log.info("VPNManager:GEN", cmd);
             this.getovpn = require('child_process').exec(cmd, (err, out, code) => {
                 if (err) {

--- a/vpn/install2.sh
+++ b/vpn/install2.sh
@@ -46,9 +46,10 @@ echo "build-dh"
 openvpn --genkey --secret keys/ta.key
 
 # Write config file for server using the template .txt file
-sed 's/LOCALIP/'$LOCALIP'/' <$FIREWALLA_HOME/vpn/server_config.txt > $FIREWALLA_HOME/vpn/server_config.txt.tmp
+sed 's/LOCALIP/'$LOCALIP'/' <$FIREWALLA_HOME/vpn/server_config.txt > /etc/openvpn/server.conf
 # Set DNS
-sed 's/MYDNS/'$DNS'/' <$FIREWALLA_HOME/vpn/server_config.txt.tmp >/etc/openvpn/server.conf
+sed -i "s=MYDNS=$DNS=" /etc/openvpn/server.conf
+# sed 's/MYDNS/'$DNS'/' <$FIREWALLA_HOME/vpn/server_config.txt.tmp >/etc/openvpn/server.conf
 if [ $ENCRYPT = 2048 ]; then
  sed -i 's:dh1024:dh2048:' /etc/openvpn/server.conf
 fi

--- a/vpn/ovpngen.sh
+++ b/vpn/ovpngen.sh
@@ -2,12 +2,19 @@
 
 : ${FIREWALLA_HOME:=/home/pi/firewalla}
 
-# ovpngen <clientname> <keypassword> local  <publicip> 
+# ovpngen <clientname> <keypassword> <local ip> <publicip> <dns>
 
 LOCALIP=$3
+DNS=$5
+: ${DNS:="8.8.8.8"}
+
 
 # Write config file for server using the template .txt file
 sed 's/LOCALIP/'$LOCALIP'/' <$FIREWALLA_HOME/vpn/server_config.txt >/etc/openvpn/server.conf
+
+# Set DNS
+sed -i "s=MYDNS=$DNS=" /etc/openvpn/server.conf
+
 if [ $ENCRYPT = 2048 ]; then
  sed -i 's:dh1024:dh2048:' /etc/openvpn/server.conf
 fi


### PR DESCRIPTION
Why server.conf was updated twice? and the second time of the file update won't take effective unless openvpn is manually restarted... 

* openvpn daemon start, read server.conf
* turn on VPN at app side, ovpngen.sh is executed, server.conf is updated
* openvpn daemon is still using the conf from the old version until the daemon is restarted