### PR TITLE
fix bro process monitoring cron job

### DIFF
--- a/etc/bro-cron2
+++ b/etc/bro-cron2
@@ -4,8 +4,20 @@ logger "brocron2 running"
 /usr/bin/sudo /bin/rm -r -f /bspool/bro/*-*_*.log
 /usr/bin/sudo /bin/rm -r -f /bspool/tmp/post-terminate*
 /usr/bin/sudo /bin/rm -r -f /bspool/tmp/*
-if [ ! -f /bspool/bro/.pid ]; then
+
+
+#check whether bro process is running using ps -ef
+#normally, bro process should contain following 3:
+#/bin/bash /usr/local/bro/share/broctl/scripts/run-bro -1 -i eth0 -U .status -p broctl -p broctl-live -p standalone -p local -p bro local.bro broctl broctl/standalone broctl/auto
+#/usr/local/bro/bin/bro -i eth0 -U .status -p broctl -p broctl-live -p standalone -p local -p bro local.bro broctl broctl/standalone broct/usr/local/bro/bin/bro -i eth0 -U .status -p broctl -p broctl-live -p standalone -p local -p bro local.bro broctl broctl/standalone broctl/auto
+#/usr/local/bro/bin/bro -i eth0 -U .status -p broctl -p broctl-live -p standalone -p local -p bro local.bro broctl broctl/standalone broctl/auto
+
+    
+bro_process_cnt=`ps -ef |grep "broctl/standalone broctl/auto" | grep -v grep | wc -l`
+logger "detected bro process count:$bro_process_cnt"    
+if [[ $bro_process_cnt != 3 ]]; then
     logger 'bro restart due to bro vanished'
     sudo service brofish stop
     sudo service brofish start
 fi
+


### PR DESCRIPTION
use ps -ef to make sure 3 bro process are running instead of checking pid file. If 3 bro process are not running, restart bro service.