### PR TITLE
remove bak dirs before mv, which would fail otherwise

### DIFF
--- a/scripts/system-reset-all-overlayfs.sh
+++ b/scripts/system-reset-all-overlayfs.sh
@@ -15,6 +15,7 @@ sudo rm -fr ${FIREWALLA_LOG_DIR}/*/*
 : ${FIREWALLA_UPPER_DIR:=/media/root-rw/overlay}
 : ${FIREWALLA_UPPER_WORK_DIR:=/media/root-rw/overlay-workdir}
 
+sudo rm -rf ${FIREWALLA_UPPER_DIR}.bak ${FIREWALLA_UPPER_WORK_DIR}.bak
 sudo mv ${FIREWALLA_UPPER_DIR}{,.bak}
 sudo mv ${FIREWALLA_UPPER_WORK_DIR}{,.bak}
 


### PR DESCRIPTION
Fix a bug in reset for overlayfs , where it needs to remove .bak dirs before rename overlay dirs into .bak ones.