### PR TITLE
increase revert timeout to 4 minutes

### DIFF
--- a/net2/ModeManager.js
+++ b/net2/ModeManager.js
@@ -41,7 +41,7 @@ let rclient = redis.createClient();
 
 Promise.promisifyAll(redis.RedisClient.prototype);
 
-const AUTO_REVERT_INTERVAL = 180 * 1000 // 3 minutes
+const AUTO_REVERT_INTERVAL = 240 * 1000 // 4 minutes
 
 let timer = null
 


### PR DESCRIPTION
this is to ensure revert won't happen during the period of safe launch