### PR TITLE
Patch 20171218: bug fixes

### DIFF
--- a/net2/SysManager.js
+++ b/net2/SysManager.js
@@ -147,7 +147,6 @@ module.exports = class {
               });
           },1000*60*60*24);
 
-          return false;
         }
         this.update(null);
         return instance;

--- a/scripts/bro-run
+++ b/scripts/bro-run
@@ -57,6 +57,9 @@ sudo cp /home/pi/firewalla/etc/firekick.service /etc/systemd/system/.
 sudo cp /home/pi/firewalla/etc/fireui.service /etc/systemd/system/.
 sudo cp /home/pi/firewalla/etc/fireapi.service /etc/systemd/system/.
 sudo cp /home/pi/firewalla/etc/fireupgrade.service /etc/systemd/system/.
+sudo cp /home/pi/firewalla/etc/bitbridge4.service /etc/systemd/system/.
+sudo cp /home/pi/firewalla/etc/bitbridge6.service /etc/systemd/system/.
+
 sudo systemctl reenable fireupgrade
 sudo systemctl daemon-reload
 sudo cp /home/pi/firewalla/etc/broctl.cfg  /usr/local/bro/etc/broctl.cfg


### PR DESCRIPTION
* [Stability] Update bitbridge config files during bro-run to make sure it's always latest
* [Bug] Fixed a brain-dead bug on sysManager init
* [Bug] Fixed a bug that it may fail to generate large transfer alarm if destination ip doesn't have dns.