### PR TITLE
Patch 20171218: bug fix

### DIFF
--- a/net2/SysManager.js
+++ b/net2/SysManager.js
@@ -147,7 +147,6 @@ module.exports = class {
               });
           },1000*60*60*24);
 
-          return false;
         }
         this.update(null);
         return instance;


### PR DESCRIPTION
[Bug] Fixed a bug that it may fail to generate large transfer alarm if destination ip doesn't have dns.