### PR TITLE
Enabled HW watchdog / Code to send configs to cloud

### DIFF
--- a/net2/HostManager.js
+++ b/net2/HostManager.js
@@ -1851,6 +1851,39 @@ module.exports = class {
     return Promise.all(ipList.map((ip) => flowManager.migrateFromOldTableForHost(ip)));
   }
 
+    /* 
+     * data here may be used to recover Firewalla configuration 
+     */
+    getCheckInAsync() {
+        return async(() => {
+          let json = {};
+          let requiredPromises = [
+            this.policyDataForInit(json),
+            this.modeForInit(json),
+            this.policyRulesForInit(json),
+            this.exceptionRulesForInit(json),
+            this.natDataForInit(json),
+            this.ignoredIPDataForInit(json),
+          ]
+
+          this.basicDataForInit(json, {});
+
+          await (requiredPromises);
+
+          let firstBinding = await (rclient.getAsync("firstBinding"))
+          if(firstBinding) {
+            json.firstBinding = firstBinding
+          }
+
+          json.bootingComplete = await (f.isBootingComplete())
+
+          // Delete anything that may be private
+          if (json.ssh) delete json.ssh
+
+          return json;
+        })();
+    }
+
     toJson(includeHosts, options, callback) {
 
       if(typeof options === 'function') {

--- a/scripts/fire-ping.sh
+++ b/scripts/fire-ping.sh
@@ -25,10 +25,11 @@ fi
 #DEFAULT_ROUTE=$(ip route show default | awk '/default/ {print $3}')
 DEFAULT_ROUTE=$(ip r |grep eth0 | grep default | cut -d ' ' -f 3 | sed -n '1p')
 
+sudo touch /dev/watchdog 
+
 for i in `seq 1 5`; do
-    if ping -c 1 $DEFAULT_ROUTE &> /dev/null
+    if ping -w 1 -c 1 $DEFAULT_ROUTE &> /dev/null
     then
-#      sudo touch /dev/watchdog
 #      /home/pi/firewalla/scripts/firelog -t debug -m"FIREWALLA PING WRITE"
        exit 0
     else
@@ -57,7 +58,6 @@ else
    exit 0
 fi
 
-#sudo touch /dev/watchdog
 /home/pi/firewalla/scripts/firelog -t debug -m "FIREWALLA PING WRITE2"
 
 

--- a/scripts/fire-reboot-normal
+++ b/scripts/fire-reboot-normal
@@ -2,12 +2,14 @@
 logger "FIREWALLA REBOOT NORMAL"
 #sudo sh -c 'echo V > /dev/watchdog'
 #sudo sh -c 'echo V > /dev/watchdog'
-sudo pkill bitbridge
-sudo pkill fire-ping
-sudo pkill sleep
+sudo service firemain stop
 sleep 4
+sync
 crontab -r
-#sudo sh -c 'echo V > /dev/watchdog'
+sudo pkill fire-ping
+sudo pkill fire-watchdog
+sleep 1
+sudo sh -c 'echo V > /dev/watchdog'
 sudo /home/pi/firewalla/scripts/fake-hwclock
 #sudo log2ram write
 sync

--- a/scripts/fire-reboot-normalf
+++ b/scripts/fire-reboot-normalf
@@ -2,19 +2,14 @@
 logger "FIREWALLA REBOOT NORMAL FORCED"
 #sudo sh -c 'echo V > /dev/watchdog'
 #sudo sh -c 'echo V > /dev/watchdog'
-sudo pkill bitbridge
-sudo pkill fire-ping
-sudo pkill sleep
-sleep 4
+sync
 crontab -r
+sudo pkill fire-ping
+sudo pkill fire-watchdog
+sleep 1
+sudo sh -c 'echo V > /dev/watchdog'
 sudo /home/pi/firewalla/scripts/fake-hwclock
-#sudo sh -c 'echo V > /dev/watchdog'
-
-# Save fake hwclock before force reboot
-sudo fake-hwclock
-# flush syslog
-# sudo /etc/cron.hourly/log2ram
-sudo /usr/local/sbin/log2ram write
+#sudo log2ram write
 sync
 sync
 sync

--- a/scripts/scheduled_reboot.sh
+++ b/scripts/scheduled_reboot.sh
@@ -13,6 +13,8 @@ fi
 mode=$(redis-cli get mode)
 
 if [ "$mode" == "dhcp" ]; then
+  touch /home/pi/.firewalla/managed_reboot
+  sync
   /home/pi/firewalla/scripts/firelog -t cloud -m "FIREWALLA.REBOOT SCHEDULED REBOOT IS DISABLED FOR DHCP MODE"
   /home/pi/firewalla/scripts/restart-services.sh
   exit 0

--- a/scripts/scheduled_reboot.sh
+++ b/scripts/scheduled_reboot.sh
@@ -14,6 +14,7 @@ mode=$(redis-cli get mode)
 
 if [ "$mode" == "dhcp" ]; then
   /home/pi/firewalla/scripts/firelog -t cloud -m "FIREWALLA.REBOOT SCHEDULED REBOOT IS DISABLED FOR DHCP MODE"
+  /home/pi/firewalla/scripts/restart-services.sh
   exit 0
 fi 
 

--- a/sensor/BoneSensor.js
+++ b/sensor/BoneSensor.js
@@ -40,6 +40,9 @@ let fConfig = require('../net2/config.js').getConfig();
 
 let sem = require('../sensor/SensorEventManager.js').getInstance();
 
+let HostManager = require("../net2/HostManager.js");
+let hostManager = new HostManager("cli", 'client', 'info');
+
 class BoneSensor extends Sensor {
   scheduledJob() {
     Bone.waitUtilCloudReady(() => {
@@ -64,6 +67,11 @@ class BoneSensor extends Sensor {
       let sysInfo = await (sysManager.getSysInfoAsync());
 
       log.info("Checking in Cloud...",sysInfo,{});
+      try {
+        sysInfo.hostInfo = await (hostManager.getCheckInAsync());
+      } catch (e) {
+        log.error("BoneCheckIn Error fetching hostInfo",e,{});
+      }
 
       let data = await (Bone.checkinAsync(fConfig, license, sysInfo));
 


### PR DESCRIPTION
HW watchdog is needed for situations if there is anything that may cause the kernel to hang.  This is experimental until we see it is stable, should go into production.

Checkin data now will contain user configuration and alarms/... see commit comments on what's is clear text.  This data can eventually be used to recover a firewalla, as well as aid in debugging problems.  