### PR TITLE
fix dnsmasq exception

### DIFF
--- a/extension/dnsmasq/dnsmasq.js
+++ b/extension/dnsmasq/dnsmasq.js
@@ -255,13 +255,13 @@ module.exports = class DNSMASQ {
   }
 
   reload() {
-    return new Promise((resolve, reject) => {
+    return new Promise(((resolve, reject) => {
       this.start(false, (err) => {
         if (err)
           reject(err);
         resolve();
       });
-    }).bind(this);
+    }).bind(this));
   }
 
   updateTmpFilter(force, callback) {


### PR DESCRIPTION
```
Unhandled rejection TypeError: Cannot read property 'start' of null
    at Promise (/home/pi/firewalla/extension/dnsmasq/dnsmasq.js:259:12)
    at Promise._execute (/home/pi/.node_modules/bluebird/js/release/debuggability.js:300:9)
    at Promise._resolveFromExecutor (/home/pi/.node_modules/bluebird/js/release/promise.js:483:18)
    at new Promise (/home/pi/.node_modules/bluebird/js/release/promise.js:79:10)
    at reload (/home/pi/firewalla/extension/dnsmasq/dnsmasq.js:258:12)
    at delay.then (/home/pi/firewalla/util/FlowControl.js:45:23)
    at tryCatcher (/home/pi/.node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/pi/.node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/home/pi/.node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/home/pi/.node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/home/pi/.node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/home/pi/.node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/home/pi/.node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/home/pi/.node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:785:20)
    at tryOnImmediate (timers.js:747:5)
    at processImmediate [as _immediateCallback] (timers.js:718:5)
INFO 2017-12-18 16:12:28 HostManager: Spoof For IPv6 E4:98
```