### PR TITLE
adding family:4 take care issue with node and request module

### DIFF
--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -278,6 +278,7 @@ let legoEptCloud = class {
         //log("Assertion"+JSON.stringify(assertion));
         let options = {
             uri: this.endpoint + '/login/eptoken',
+            family: 4,
             method: 'POST',
 
             json: assertion
@@ -363,6 +364,7 @@ let legoEptCloud = class {
 
         let options = {
             uri: this.endpoint + '/group/' + this.appId,
+            family: 4,
             method: 'POST',
             auth: {
                 bearer: this.token
@@ -398,6 +400,7 @@ let legoEptCloud = class {
     eptFind(eid, callback) {
         let options = {
             uri: this.endpoint + '/ept/' + encodeURIComponent(eid),
+            family: 4,
             method: 'GET',
             auth: {
                 bearer: this.token
@@ -429,6 +432,7 @@ let legoEptCloud = class {
     eptGroupList(eid, callback) {
         let options = {
             uri: this.endpoint + '/ept/' + encodeURIComponent(eid) + '/groups',
+            family: 4,
             method: 'GET',
             auth: {
                 bearer: this.token
@@ -473,6 +477,7 @@ let legoEptCloud = class {
    rendezvousMap (rid, callback) {
         let options = {
             uri: this.endpoint + '/ept/rendezvous/' + rid,
+            family: 4,
             method: 'GET',
             auth: {
                 bearer: this.token
@@ -506,6 +511,7 @@ let legoEptCloud = class {
         }
         let options = {
             uri: this.endpoint + '/group/' + this.appId + "/" + gid,
+            family: 4,
             method: 'GET',
             auth: {
                 bearer: this.token
@@ -742,6 +748,7 @@ let legoEptCloud = class {
       // log.info('encrypted text ', crypted);
       let options = {
         uri: self.endpoint + '/service/message/' + self.appId + '/' + gid + '/eptgroup/' + gid,
+        family: 4,
         method: 'POST',
         auth: {
           bearer: self.token
@@ -857,6 +864,7 @@ let legoEptCloud = class {
 
             let options = {
                 uri: self.endpoint + '/service/message/' + self.appId + "/" + gid + '/eptgroup/' + encodeURIComponent(self.eid) + '?count=' + count + '&peerId=' + gid + '&since=' + timestamp,
+                family: 4,
                 method: 'GET',
                 auth: {
                     bearer: self.token
@@ -1222,6 +1230,7 @@ let legoEptCloud = class {
                                 if (peerKey != null) {
                                     let options = {
                                         uri: self.endpoint + '/group/' + self.appId + "/" + grp._id + "/" + encodeURIComponent(eid),
+                                        family: 4,
                                         method: 'POST',
                                         auth: {
                                             bearer: self.token
@@ -1286,6 +1295,7 @@ let legoEptCloud = class {
     getStorage(gid, size, expires, callback) {
         let options = {
             uri: this.endpoint + '/service/message/storage/' + gid + '?size=' + size + '&expires=' + expires,
+            family: 4,
             method: 'GET',
             auth: {
                 bearer: this.token

--- a/lib/Bone.js
+++ b/lib/Bone.js
@@ -214,6 +214,7 @@ exports.getLicense = function(luid, mac, callback) {
   let cpuid = utils.getCpuId() || "0";
   let options = {
     uri: licenseServer + '/license/issue/' + luid + "?mac=" + mac+"&serial="+cpuid,
+    family: 4,
     method: 'GET',
     auth: {
       bearer: token
@@ -294,6 +295,7 @@ exports.checkin = function(config, license, info, callback) {
 
   let options = {
     uri: endpoint + '/sys/checkin',
+    family: 4,
     method: 'POST',
     auth: {
       bearer: token
@@ -373,6 +375,7 @@ exports.device = function(cmd, obj, callback) {
   log.info("sending POST request: /device/" + cmd);
   let options = {
     uri: getEndpoint() + '/device/' + cmd,
+    family: 4,
     method: 'POST',
     auth: {
       bearer: getToken()
@@ -418,6 +421,7 @@ exports.log = function(cmd, obj, callback) {
   log.info("/device/log/" + cmd);
   let options = {
     uri: getEndpoint() + '/device/log/' + cmd,
+    family: 4,
     method: 'POST',
     auth: {
       bearer: getToken()
@@ -467,6 +471,7 @@ exports.intel = function(ip, type, action, intel, callback) {
   log.debug("/intel/host/" + ip + "/" + action);
   let options = {
     uri: getEndpoint() + '/intel/host/' + ip + '/' + action,
+    family: 4,
     method: 'POST',
     auth: {
       bearer: getToken()
@@ -528,6 +533,7 @@ exports.intelAsync = Promise.promisify(exports.intel);
 exports.flowgraph = function(action, obj, callback) {
   let options = {
     uri: getEndpoint() + '/flowgraph/' + action,
+    family: 4,
     method: 'POST',
     auth: {
       bearer: getToken()
@@ -573,6 +579,7 @@ exports.hashset = function(hashsetid, callback) {
   log.info("/hashset/" + hashsetid);
   let options = {
     uri: getEndpoint() + '/intel/hashset/' + hashsetid,
+    family: 4,
     method: 'GET',
     auth: {
       bearer: getToken()
@@ -635,6 +642,7 @@ exports.getServiceConfig = function(callback) {
   let url = getEndpoint() + '/service/config';
   let options = {
     uri: url,
+    family: 4,
     method: 'GET',
     auth: {
       bearer: getToken()
@@ -670,6 +678,7 @@ const flowUtil = require('../net2/FlowUtil');
 let intelFeedback = function(feedback, callback) {
   let options = {
     uri: getEndpoint() + '/intel/feedback/',
+    family: 4,
     method: 'POST',
     auth: {
       bearer: getToken()


### PR DESCRIPTION
we are seen sometimes domain lookup fails (getaddrinfo ENOTFOUND) , this is an issue with node/request.  forcing request to be family:4 is a workaround until someone fixes the root cause, which is in node itself.

https://github.com/request/request-promise-native/issues/6