### PR TITLE
Revert "BUG: 218.* devices are not loaded during loading init data"

### DIFF
--- a/net2/SysManager.js
+++ b/net2/SysManager.js
@@ -657,10 +657,7 @@ module.exports = class {
                 return true;
             }
 
-            return iptool.cidrSubnet(this.subnet).contains(ip) || 
-            this.isLocalIP4(this.config.monitoringInterface2,ip) || 
-            this.sysinfo[this.config.monitoringInterface2] == null; // consider IP valid if monitoringInterface2 is not loaded yet.
-
+            return iptool.cidrSubnet(this.subnet).contains(ip) || this.isLocalIP4(this.config.monitoringInterface2,ip);
         } else if (iptool.isV6Format(ip)) {
             if (ip.startsWith('::')) {
                 return true;


### PR DESCRIPTION
This reverts commit b8c8b3b3d857a12b959cad965db5b2d9991e85d0.

## Notice
* Make sure node modules are well updated before submitting pull requests to firewalla repository
* Node modules repository for armv7l: https://github.com/firewalla/fnm.node8.armv7l.git
