### PR TITLE
Fails to fetch ip location info won't impact alarm generation

### DIFF
--- a/net2/IntelManager.js
+++ b/net2/IntelManager.js
@@ -330,33 +330,32 @@ module.exports = class {
             // Authorization: 'Token dc30fcd03eddbd95b90bacaea5e5a44b1b60d2f5',
         };
 
-        request(options, (err, httpResponse, body) => {
-            if (err != null) {
-                let stack = new Error().stack;
-                log.info("Error while requesting ", err, stack);
-                callback(err, null, null);
+        request(options, (err, resp, body) => {
+            if (err) {
+                log.warn(`Error while requesting ${weburl}`, err);
+                callback(null, null);
                 return;
             }
-            if (httpResponse == null) {
-                let stack = new Error().stack;
-                log.info("Error while response ", err, stack);
-                callback(500, null, null);
+            if (!resp) {
+                log.warn(`Error - null response from ${weburl}`);
+                callback(null, null);
                 return;
             }
-            if (httpResponse.statusCode < 200 ||
-                httpResponse.statusCode > 299) {
-                log.error("**** Error while response HTTP ", httpResponse.statusCode);
-                callback(httpResponse.statusCode, null, null);
+            if (resp.statusCode < 200 || resp.statusCode > 299) {
+                log.warn("Error in response code", resp.statusCode);
+                callback(null, null);
                 return;
             }
-            if (err === null && body != null) {
-                this.cacheAdd(ip, "ipinfo", body);
+            if (body) {
                 let obj = JSON.parse(body);
-                if (obj != null) {
-                    callback(null,obj);
+                if (obj) {
+                    this.cacheAdd(ip, "ipinfo", body);
+                    callback(null, obj);
                 } else {
-                    callback(null,null);
+                    callback(null, null);
                 }
+            } else {
+              callback(null, null);
             }
         });
       });
@@ -371,7 +370,7 @@ module.exports = class {
             family: 4
         };
 
-        this._location(ip, (err,lobj)=>{
+        this._location(ip, (err, lobj)=>{
             let obj = {lobj};
             log.info("Intel:Location",ip,lobj);
             obj = this._packageIntel(ip,obj,intel);

--- a/net2/IntelManager.js
+++ b/net2/IntelManager.js
@@ -351,12 +351,10 @@ module.exports = class {
                 if (obj) {
                     this.cacheAdd(ip, "ipinfo", body);
                     callback(null, obj);
-                } else {
-                    callback(null, null);
+                    return;
                 }
-            } else {
-              callback(null, null);
-            }
+            } 
+            callback(null, null);
         });
       });
     }

--- a/testLegacy/malware_simulator.js
+++ b/testLegacy/malware_simulator.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs');
 var program = require('commander');
-var mathuuid = require('../lib/Math.uuid.js');
 var uuid = require("uuid");
 var exec = require('child_process').exec;
 


### PR DESCRIPTION
Fix https://github.com/firewalla/firewalla.ios/issues/609 (ipinfo.io server down causing alarm failed to generate)

# Notice

* Make sure node modules are well updated before submitting pull requests to firewalla repository
  * Node modules repository for armv7l: https://github.com/firewalla/fnm.node8.armv7l.git
* If change mgit, fire-ping, fireupgrade, check_reset, fireupgrade2.service, check_fix_network.sh  ... PLEASE CHANGE bootstrap.sha256sum
  * As an option, you can run command **cd .git; ln -s ../.githooks hooks** to enable sha256sum auto validation during commit