### PR TITLE
BUG: should copy watchdog.conf over when it's updated

### DIFF
--- a/scripts/post_run.sh
+++ b/scripts/post_run.sh
@@ -21,9 +21,9 @@ if [ $(dpkg-query -W -f='${Status}' watchdog 2>/dev/null | grep -c "ok installed
 then
     if [[ $PLATFORM == "armv7l" ]]; then
         sudo dpkg -i ${FIREWALLA_HOME}/vendor/watchdog_5.14-3ubuntu0.16.04.1_armhf.deb
-        sudo cp ${FIREWALLA_HOME}/etc/watchdog.conf /etc/watchdog.conf
     elif [[ $PLATFORM == "x86_64" ]]; then
         sudo apt-get install watchdog
-        sudo cp ${FIREWALLA_HOME}/etc/watchdog.conf /etc/watchdog.conf
     fi
 fi
+
+cmp --silent ${FIREWALLA_HOME}/etc/watchdog.conf /etc/watchdog.conf || sudo cp ${FIREWALLA_HOME}/etc/watchdog.conf /etc/watchdog.conf


### PR DESCRIPTION
# Notice

* Make sure node modules are well updated before submitting pull requests to firewalla repository
  * Node modules repository for armv7l: https://github.com/firewalla/fnm.node8.armv7l.git
* If change mgit, fire-ping, fireupgrade, check_reset, fireupgrade2.service, check_fix_network.sh  ... PLEASE CHANGE bootstrap.sha256sum
  * As an option, you can run command **cd .git; ln -s ../.githooks hooks** to enable sha256sum auto validation during commit