### PR TITLE
Add cronjob to restart bitbridge7 if necessary

### DIFF
--- a/etc/brotab
+++ b/etc/brotab
@@ -5,6 +5,7 @@ SHELL=/bin/bash
 0 0 */5 * *  /home/pi/firewalla/scripts/scheduled_reboot.sh &>/dev/null
 0 0 1-31/2 * * /home/pi/firewalla/scripts/clean-log >/dev/null 2>&1
 * * * * * for x in $(seq 0 10 50); do ( sleep $x; /home/pi/scripts/fire-ping.sh  &>/dev/null) & done
+*/1 * * * * ( /home/pi/firewalla/scripts/bitbridge-ping.sh  >/dev/null 2>&1 )
 */2 * * * * ( /home/pi/firewalla/scripts/fireapi-ping.sh  >/dev/null 2>&1 )
 */10 * * * * ( /home/pi/firewalla/scripts/firemain-ping.sh  >/dev/null 2>&1 )
 */5 * * * * ( /home/pi/firewalla/scripts/firemon-ping.sh  >/dev/null 2>&1 )

--- a/scripts/bitbridge-ping.sh
+++ b/scripts/bitbridge-ping.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# -----------------------------------------
+# This is a watch dog function for bitbridge7.
+# In case of redis connection loss, 
+# need to restart bitbridge7.
+# -----------------------------------------
+
+bitbridge7_ping () {
+    RESULT=$(sudo netstat -anlp | grep bitbridge7 | grep 6379 | grep ESTABLISHED || pgrep bitbridge7)
+    ret=$?
+    if [[ $? != 0 ]]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+if bitbridge7_ping; then
+    exit 0
+else
+    # binary is bitbridge7, however service name is bitbridge4...
+    sudo systemctl restart bitbridge4
+fi


### PR DESCRIPTION
This is a workaround for firewalla/firewalla.ios#858