### PR TITLE
new feature: remote port block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ api/db/token.json
 /test
 /.gitmodules
 /extension/frp/frpc.ini
+
+.tern-port
+.tern-project

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -52,7 +52,7 @@ const ht = new HostTool()
 const DomainIPTool = require('../control/DomainIPTool.js');
 const domainIPTool = new DomainIPTool();
 
-const domainBlock = require('../control/DomainBlock.js')()
+const domainBlock = require('../control/DomainBlock.js')();
 
 const CategoryUpdater = require('../control/CategoryUpdater.js')
 const categoryUpdater = new CategoryUpdater()
@@ -117,71 +117,70 @@ class PolicyManager2 {
       log.info("policy queue is cleaned up")
     })
 
-    this.queue.process((job, done) => {
+    this.queue.process(async (job) => {
       const event = job.data;
       const policy = new Policy(event.policy);
       const oldPolicy = event.oldPolicy ? new Policy(event.oldPolicy) : null;
       const action = event.action
 
       if(this.shouldFilter(policy)) {
-        done();
         return;
       }
 
       switch(action) {
       case "enforce": {
-        return async(() => {
+        try {
           log.info("START ENFORCING POLICY", policy.pid, action);
-          await(this.enforce(policy))
-        })().catch((err) => {
+          await this.enforce(policy)
+        } catch(err) {
           log.error("enforce policy failed:" + err, policy)
-        }).finally(() => {
+        } finally {
           log.info("COMPLETE ENFORCING POLICY", policy.pid, action);
-          done()
-        })
+          return
+        }
         break
       }
 
       case "unenforce": {
-        return async(() => {
+        try {
           log.info("START UNENFORCING POLICY", policy.pid, action);
-          await(this.unenforce(policy))
-        })().catch((err) => {
+          await this.unenforce(policy)
+        } catch(err) {
           log.error("unenforce policy failed:" + err, policy)
-        }).finally(() => {
+        } finally {
           log.info("COMPLETE UNENFORCING POLICY", policy.pid, action);
-          done()
-        })
+          return
+        }
         break
       }
 
       case "reenforce": {
-        return async(() => {
+        try {
           if(!oldPolicy) {
             // do nothing
           } else {
             log.info("START REENFORCING POLICY", policy.pid, action);
 
-            await(this.unenforce(oldPolicy))
-            await(this.enforce(policy))
+            await this.unenforce(oldPolicy)
+            await this.enforce(policy)
           }
-        })().catch((err) => {
+        } catch(err) {
           log.error("reenforce policy failed:" + err, policy)
-        }).finally(() => {
+        } finally {
           log.info("COMPLETE ENFORCING POLICY", policy.pid, action);
-          done()
-        })
+          return
+        }
         break
       }
 
       case "incrementalUpdate": {
-        return async(() => {
-          const list = await (domainIPTool.getAllIPMappings())
-          list.forEach((l) => {
+        try {
+          const list = await domainIPTool.getAllIPMappings()
+          for (const l of list) {
             const matchDomain = l.match(/ipmapping:domain:(.*)/)
             if(matchDomain) {
               const domain = matchDomain[1]
-              await (domainBlock.incrementalUpdateIPMapping(domain, {}))
+              await domainBlock.incrementalUpdateIPMapping(domain, {})
               return
             }
 
@@ -189,14 +188,14 @@ class PolicyManager2 {
             if (matchBlockSetDomain) {
               const blockSet = matchBlockSetDomain[1];
               const domain = matchBlockSetDomain[2];
-              await (domainBlock.incrementalUpdateIPMapping(domain, {blockSet: blockSet}))
+              await domainBlock.incrementalUpdateIPMapping(domain, {blockSet: blockSet})
               return;
             }
 
             const matchExactDomain = l.match(/ipmapping:exactdomain:(.*)/)
             if(matchExactDomain) {
               const domain = matchExactDomain[1]
-              await (domainBlock.incrementalUpdateIPMapping(domain, {exactMatch: 1}))
+              await domainBlock.incrementalUpdateIPMapping(domain, {exactMatch: 1})
               return
             }
 
@@ -204,21 +203,20 @@ class PolicyManager2 {
             if (matchBlockSetExactDomain) {
               const blockSet = matchBlockSetExactDomain[1];
               const domain = matchBlockSetExactDomain[2];
-              await (domainBlock.incrementalUpdateIPMapping(domain, {exactMatch: 1, blockSet: blockSet}));
+              await domainBlock.incrementalUpdateIPMapping(domain, {exactMatch: 1, blockSet: blockSet});
             }
-          })
-        })().catch((err) => {
+          }
+        } catch(err) {
           log.error("incremental update policy failed:", err);
-        }).finally(() => {
+        } finally {
           log.info("COMPLETE incremental update policy");
-          done()
-        })
+          return
+        }
       }
 
       default:
         log.error("unrecoganized policy enforcement action:" + action)
-        done()
-        break
+        return
       }
     })
 
@@ -726,10 +724,8 @@ class PolicyManager2 {
   }
 
   // cleanup before use
-  cleanupPolicyData() {
-    return async(() => {
-      await (domainIPTool.removeAllDomainIPMapping())
-    })()
+  async cleanupPolicyData() {
+    await domainIPTool.removeAllDomainIPMapping()
   }
 
   async enforceAllPolicies() {
@@ -905,6 +901,42 @@ class PolicyManager2 {
     return policy;
   }
 
+  generateTaget(policy) {
+    const { type, target, protocol, ip, net, port } = policy
+    if (!_.isEmpty(target)) return target
+
+    if (!_.isEmpty(ip) && !_.isArray(ip)) ip = [ip]
+    if (!_.isEmpty(ip) && !_.isArray(net)) net = [net]
+    if (!_.isEmpty(ip) && !_.isArray(port)) port = [port]
+
+    switch (type) {
+      case 'ip':
+        return ip
+      case 'net':
+        return net
+      case 'remotePort':
+        return port
+      case 'remoteIpPort':
+        let res = []
+        for (const i of ip)
+          for (const p of port)
+            if (protocol)
+              res.push(`${i},${protocol}:${p}`)
+            else
+              res.push(`${i}:${p}`)
+        return res
+      case 'remoteNetPort':
+        let res = []
+        for (const n of net)
+          for (const p of port)
+            if (protocol)
+              res.push(`${n},${protocol}:${p}`)
+            else
+              res.push(`${n}:${p}`)
+        return res
+    }
+  }
+
   async _enforce(policy) {
     log.info("Enforce policy:", policy.pid, policy.type, policy.target, policy.scope, policy.whitelist);
 
@@ -922,30 +954,46 @@ class PolicyManager2 {
 
     switch(type) {
       case "ip":
+      case "net":
+      case "remotePort":
+      case "remoteIpPort":
+      case "remoteNetPort":
         if (scope) {
-          await Block.setupRules(pid, pid, "hash:ip", whitelist);
-          await Block.addMacToSet(pid, scope);
+          const setType = {
+            'ip': 'hash:ip',
+            'net': 'hash:net',
+            'remotePort': 'bitmap:port',
+            'remoteIpPort': 'hash:ip,port',
+            'remoteNetPort': 'hash:net,port'
+          }
+
+          await Block.setupRules(pid, pid, setType[type], whitelist);
+          await Block.addMacToSet(scope, Block.getMacSet(pid));
           await Block.block(target, Block.getDstSet(pid), whitelist)
         } else {
-          if (policy.whitelist) await Block.enableGlobalWhitelist()
-          await Block.block(target, null, whitelist)
+          const setMap = {
+            'ip': 'ip_set',
+            'net': 'net_set',
+            'remotePort': 'remote_port_set',
+            'remoteIpPort': 'remote_ip_port_set',
+            'remoteNetPort': 'remote_net_port_set'
+          }
+          const set = (whitelist ? 'whitelist_' : 'blocked_') + setMap[type]
+
+          await Block.block(target, set, whitelist)
         }
         break;
 
       case "mac":
-        if (whitelist) {
-          await Block.enableGlobalWhitelist();
-          await Block.blockMac(target, "whitelist_mac_set");
-        } else {
-          await Block.blockMac(target);
-        }
+        await Block.addMacToSet([target], null, whitelist)
+        accounting.addBlockedDevice(target);
         break;
 
       case "domain":
       case "dns":
         if(scope) {
           await Block.setupRules(scope && pid, pid, "hash:ip", whitelist);
-          await Block.addMacToSet(pid, scope);
+          await Block.addMacToSet(scope, Block.getMacSet(pid));
           await domainBlock.blockDomain(target, {
             exactMatch: policy.domainExactMatch,
             blockSet: Block.getDstSet(pid),
@@ -959,7 +1007,6 @@ class PolicyManager2 {
             // whitelist rule should not add dnsmasq filter rule
             options.no_dnsmasq_entry = true;
             options.no_dnsmasq_reload = true;
-            await Block.enableGlobalWhitelist();
           }
           await domainBlock.blockDomain(target, options);
         }
@@ -969,7 +1016,6 @@ class PolicyManager2 {
         let data = await this.parseDevicePortRule(target);
         if(data) {
           if (whitelist) {
-            await Block.enableGlobalWhitelist();
             await Block.blockPublicPort(data.ip, data.port, data.protocol, "whitelist_ip_port_set");
           } else {
             await Block.blockPublicPort(data.ip, data.port, data.protocol)
@@ -979,7 +1025,7 @@ class PolicyManager2 {
 
       case "category":
         await Block.setupRules(scope && pid, target, "hash:ip", whitelist);
-        await Block.addMacToSet(pid, scope);
+        await Block.addMacToSet(scope, Block.getMacSet(pid));
 
         if (!scope && !whitelist && target === 'default_c') try {
           await categoryUpdater.iptablesRedirectCategory(target)
@@ -988,20 +1034,10 @@ class PolicyManager2 {
         }
         break;
 
-      case "net":
-        if (scope) {
-          await Block.setupRules(pid, pid, "hash:net", whitelist);
-          await Block.addMacToSet(pid, scope);
-          await Block.block(target, Block.getDstSet(pid), whitelist)
-        } else {
-          await Block.block(target, null, whitelist)
-        }
-        break;
-
       case "country":
         await countryUpdater.activateCountry(target);
         await Block.setupRules(scope && pid, countryUpdater.getCategory(target), "hash:net", whitelist);
-        await Block.addMacToSet(pid, scope);
+        await Block.addMacToSet(scope, Block.getMacSet(pid));
         break;
 
       default:
@@ -1039,32 +1075,40 @@ class PolicyManager2 {
 
     switch(type) {
       case "ip":
+      case "net":
+      case "remotePort":
+      case "remoteIpPort":
+      case "remoteNetPort":
         if (scope) {
           await Block.destroyRules(pid, pid, whitelist);
         } else {
-          if (policy.whitelist) await Block.disableGlobalWhitelist()
-          await Block.unblock(target, null, whitelist)
+          const setMap = {
+            'ip': 'ip_set',
+            'net': 'net_set',
+            'remotePort': 'remote_port_set',
+            'remoteIpPort': 'remote_ip_port_set',
+            'remoteNetPort': 'remote_net_port_set'
+          }
+          const set = (whitelist ? 'whitelist_' : 'blocked_') + setMap[type]
+
+          await Block.unblock(target, set, whitelist)
         }
         break;
 
       case "mac":
-        if (whitelist) {
-          await Block.disableGlobalWhitelist();
-          await Block.unblockMac(target, "whitelist_mac_set");
-        } else {
-          await Block.unblockMac(target)
-        }
+        await Block.delMacFromSet([target], null, whitelist)
+        accounting.removeBlockedDevice(target);
         break;
 
       case "domain":
       case "dns":
         if(scope) {
-          await (domainBlock.unblockDomain(target, {
+          await domainBlock.unblockDomain(target, {
             exactMatch: policy.domainExactMatch,
             blockSet: Block.getDstSet(pid),
             no_dnsmasq_entry: true,
             no_dnsmasq_reload: true
-          }))
+          })
           // destroy domain dst cache, since there may be various domain dst cache in different policies
           await Block.destroyRules(pid, pid, whitelist);
         } else {
@@ -1073,17 +1117,15 @@ class PolicyManager2 {
             options.blockSet = "whitelist_domain_set";
             options.no_dnsmasq_entry = true;
             options.no_dnsmasq_reload = true;
-            await Block.disableGlobalWhitelist();
           }
           await domainBlock.unblockDomain(target, options);
         }
         break;
 
       case "devicePort":
-        let data = await (this.parseDevicePortRule(target))
+        let data = await this.parseDevicePortRule(target)
         if(data) {
           if (whitelist) {
-            await Block.disableGlobalWhitelist();
             await Block.unblockPublicPort(data.ip, data.port, data.protocol, "whitelist_ip_port_set");
           } else {
             await Block.unblockPublicPort(data.ip, data.port, data.protocol);
@@ -1098,15 +1140,6 @@ class PolicyManager2 {
           await categoryUpdater.iptablesUnredirectCategory(target)
         } catch(err) {
           log.error("Failed to redirect default_c traffic", err)
-        }
-        break;
-
-      case "net":
-        if (scope) {
-          await Block.destroyRules(pid, pid, whitelist);
-        } else {
-          if (policy.whitelist) await Block.disableGlobalWhitelist()
-          await Block.unblock(target, null, whitelist)
         }
         break;
 

--- a/control/Block.js
+++ b/control/Block.js
@@ -70,15 +70,13 @@ async function setupGlobalWhitelist(state) {
   try {
     let ruleSet = [
       new Rule().chn('FW_WHITELIST_PREROUTE').jmp('FW_WHITELIST'),
-      new Rule().chn('FORWARD').jmp('FW_WHITELIST_PREROUTE'),
       new Rule('nat').chn('FW_NAT_WHITELIST_PREROUTE').jmp('FW_NAT_WHITELIST'),
-      new Rule('nat').chn('PREROUTING').jmp('FW_NAT_WHITELIST_PREROUTE'),
     ]
 
     let ruleSet6 = ruleSet.map(r => r.clone().fam(6))
 
     for (const rule of ruleSet.concat(ruleSet6)) {
-      const op = state ? (rule.jump.endsWith('WHITELIST') ? '-A' : '-I') : '-D';
+      const op = state ? '-A' : '-D';
       await exec(rule.toCmd(op));
     }
   } catch (err) {

--- a/control/Block.js
+++ b/control/Block.js
@@ -29,19 +29,9 @@ const f = require('../net2/Firewalla.js')
 const _wrapIptables = require('../net2/Iptables.js').wrapIptables;
 const Ipset = require('../net2/Ipset.js');
 
-const WHITELIST_MARK = "0x1/0x1";
+const { Rule } = require('../net2/Iptables.js');
 
 // =============== block @ connection level ==============
-
-function getIPTablesCmd(v6) {
-  let cmd = "iptables";
-
-  if(v6) {
-    cmd = "ip6tables";
-  }
-
-  return cmd;
-}
 
 // This function MUST be called at the beginning of main.js
 async function setupBlockChain() {
@@ -76,166 +66,28 @@ function getDstSet6(tag) {
   return `c_bd_${tag}_set6`
 }
 
-async function enableGlobalWhitelist() {
+async function setupGlobalWhitelist(state) {
   try {
-    // mark all packets to divert to whitelist chain
-    // Beware that _wrapIptables is not used here in purpose. Each global whitelist rule will create a MARK policy rule
-    // so on removing we could delete one each time, and this will still be effective until all whitelist rules are removed
-    // possible performance impact on packet filtering here?
-    const cmdCreateMarkRule = `sudo iptables -w -t mangle -I PREROUTING -j CONNMARK --set-xmark ${WHITELIST_MARK}`;
-    const cmdCreateMarkRule6 = `sudo ip6tables -w -t mangle -I PREROUTING -j CONNMARK --set-xmark ${WHITELIST_MARK}`;
+    let ruleSet = [
+      new Rule().chn('FW_WHITELIST_PREROUTE').jmp('FW_WHITELIST'),
+      new Rule().chn('FORWARD').jmp('FW_WHITELIST_PREROUTE'),
+      new Rule('nat').chn('FW_NAT_WHITELIST_PREROUTE').jmp('FW_NAT_WHITELIST'),
+      new Rule('nat').chn('PREROUTING').jmp('FW_NAT_WHITELIST_PREROUTE'),
+    ]
 
-    await exec(cmdCreateMarkRule);
-    await exec(cmdCreateMarkRule6);
+    let ruleSet6 = ruleSet.map(r => r.clone().fam(6))
+
+    for (const rule of ruleSet.concat(ruleSet6)) {
+      const op = state ? (rule.jump.endsWith('WHITELIST') ? '-A' : '-I') : '-D';
+      await exec(rule.toCmd(op));
+    }
   } catch (err) {
-    log.error("Failed to enable global whitelist");
+    log.error("Failed to setup global whitelist", err);
   }
 }
 
-async function disableGlobalWhitelist() {
-  try {
-    // delete MARK policy rule in mangle table
-    const cmdDeleteMarkRule = _wrapIptables(`sudo iptables -w -t mangle -D PREROUTING -j CONNMARK --set-xmark ${WHITELIST_MARK}`);
-    const cmdDeleteMarkRule6 = _wrapIptables(`sudo ip6tables -w -t mangle -D PREROUTING -j CONNMARK --set-xmark ${WHITELIST_MARK}`);
+async function setupDeviceWhitelist(device, state) {
 
-    await exec(cmdDeleteMarkRule);
-    await exec(cmdDeleteMarkRule6);
-  } catch (err) {
-    log.error("Failed to enable global whitelist");
-  }
-}
-
-async function setupWhitelistEnv(macTag, dstTag, dstType = "hash:ip", destroy = false, destroyDstCache = true) {
-  if (!dstTag) {
-    return;
-  }
-
-  try {
-    log.info(destroy ? 'Destroying' : 'Creating', 'whitelist environment for', macTag || "null", dstTag,
-      destroy && destroyDstCache ? "and ipset" : "");
-
-    const macSet = macTag ? getMacSet(macTag) : '';
-    const dstSet = getDstSet(dstTag);
-    const dstSet6 = getDstSet6(dstTag);
-
-    if (!destroy) {
-      if (macTag) {
-        const cmdCreateMacSet = `sudo ipset create -! ${macSet} hash:mac`
-        await exec(cmdCreateMacSet);
-      } else {
-        await this.enableGlobalWhitelist();
-      }
-      const cmdCreateDstSet = `sudo ipset create -! ${dstSet} ${dstType} family inet hashsize 128 maxelem 65536`;
-      const cmdCreateDstSet6 = `sudo ipset create -! ${dstSet6} ${dstType} family inet6 hashsize 128 maxelem 65536`;
-      await exec(cmdCreateDstSet);
-      await exec(cmdCreateDstSet6);
-    }
-
-    const ops = destroy ? '-D' : '-I'
-    const matchMacSrc = macTag ? `-m set --match-set ${macSet} src` : '';
-
-    // mark packet in mangle table which indicates the packets need to go through the whitelist chain.
-    // Use insert(-I) here since there is a clear mark rule at the end of the PREROUTING chain in mangle to allow all dns packets
-    const cmdMarkRule = _wrapIptables(`sudo iptables -w -t mangle ${ops} PREROUTING ${matchMacSrc} -j CONNMARK --set-xmark ${WHITELIST_MARK}`);
-    const cmdMarkRule6 = _wrapIptables(`sudo ip6tables -w -t mangle ${ops} PREROUTING ${matchMacSrc} -j CONNMARK --set-xmark ${WHITELIST_MARK}`);
-
-    // add RETURN policy rule into whitelist chain
-    const cmdOutgoingRule = _wrapIptables(`sudo iptables -w ${ops} FW_WHITELIST -p all ${matchMacSrc} -m set --match-set ${dstSet} dst -j RETURN`);
-    const cmdOutgoingRule6 = _wrapIptables(`sudo ip6tables -w ${ops} FW_WHITELIST -p all ${matchMacSrc} -m set --match-set ${dstSet6} dst -j RETURN`);
-    // add corresponding whitelist rules into nat table
-    const cmdNatOutgoingTCPRule = _wrapIptables(`sudo iptables -w -t nat ${ops} FW_NAT_WHITELIST -p tcp ${matchMacSrc} -m set --match-set ${dstSet} dst -j RETURN`);
-    const cmdNatOutgoingUDPRule = _wrapIptables(`sudo iptables -w -t nat ${ops} FW_NAT_WHITELIST -p udp ${matchMacSrc} -m set --match-set ${dstSet} dst -j RETURN`);
-    const cmdNatOutgoingTCPRule6 = _wrapIptables(`sudo ip6tables -w -t nat ${ops} FW_NAT_WHITELIST -p tcp ${matchMacSrc} -m set --match-set ${dstSet6} dst -j RETURN`);
-    const cmdNatOutgoingUDPRule6 = _wrapIptables(`sudo ip6tables -w -t nat ${ops} FW_NAT_WHITELIST -p udp ${matchMacSrc} -m set --match-set ${dstSet6} dst -j RETURN`);
-
-    await exec(cmdMarkRule);
-    await exec(cmdOutgoingRule);
-    await exec(cmdMarkRule6);
-    await exec(cmdOutgoingRule6);
-    await exec(cmdNatOutgoingTCPRule);
-    await exec(cmdNatOutgoingUDPRule);
-    await exec(cmdNatOutgoingTCPRule6);
-    await exec(cmdNatOutgoingUDPRule6);
-
-    if (destroy) {
-      if (macTag) {
-        await Ipset.destroy(macSet)
-      } else {
-        await this.disableGlobalWhitelist();
-      }
-      if (destroyDstCache) {
-        await Ipset.destroy(dstSet)
-        await Ipset.destroy(dstSet6)
-      }
-    }
-
-    log.info('Finish', destroy ? 'destroying' : 'creating', 'whitelist environment for', macTag || "null", dstTag);
-
-  } catch (err) {
-    log.error('Error when setup whitelist env', err);
-  }
-}
-
-async function setupBlockingEnv(macTag, dstTag, dstType = "hash:ip", destroy = false, destroyDstCache = true) {
-  if (!dstTag) {
-    return;
-  }
-
-  // sudo ipset create blocked_ip_set hash:ip family inet hashsize 128 maxelem 65536
-  try {
-    log.info(destroy ? 'Destroying' : 'Creating', 'block environment for', macTag || "null", dstTag,
-      destroy && destroyDstCache ? "and ipset" : "");
-
-    const macSet = macTag ? getMacSet(macTag) : '';
-    const dstSet = getDstSet(dstTag)
-    const dstSet6 = getDstSet6(dstTag)
-
-    if (!destroy) {
-      if (macTag) {
-        const cmdCreateMacSet = `sudo ipset create -! ${macSet} hash:mac`
-        await exec(cmdCreateMacSet);
-      }
-      const cmdCreateDstSet = `sudo ipset create -! ${dstSet} ${dstType} family inet hashsize 128 maxelem 65536`
-      const cmdCreateDstSet6 = `sudo ipset create -! ${dstSet6} ${dstType} family inet6 hashsize 128 maxelem 65536`
-      await exec(cmdCreateDstSet);
-      await exec(cmdCreateDstSet6);
-    }
-
-    const ops = destroy ? '-D' : '-I'
-    const matchMacSrc = macTag ? `-m set --match-set ${macSet} src` : '';
-    const matchMacDst = macTag ? `-m set --match-set ${macSet} dst` : '';
-
-    // add rules in filter table
-    const cmdOutgoingRule = _wrapIptables(`sudo iptables -w ${ops} FW_BLOCK -p all ${matchMacSrc} -m set --match-set ${dstSet} dst -j FW_DROP`)
-    const cmdIncomingRule = _wrapIptables(`sudo iptables -w ${ops} FW_BLOCK -p all ${matchMacDst} -m set --match-set ${dstSet} src -j FW_DROP`)
-    const cmdOutgoingRule6 = _wrapIptables(`sudo ip6tables -w ${ops} FW_BLOCK -p all ${matchMacSrc} -m set --match-set ${dstSet6} dst -j FW_DROP`)
-    const cmdIncomingRule6 = _wrapIptables(`sudo ip6tables -w ${ops} FW_BLOCK -p all ${matchMacDst} -m set --match-set ${dstSet6} src -j FW_DROP`)
-    // add rules in nat table
-    const cmdNatOutgoingRule = _wrapIptables(`sudo iptables -w -t nat ${ops} FW_NAT_BLOCK ${matchMacSrc} -m set --match-set ${dstSet} dst -j FW_NAT_HOLE`)
-    const cmdNatOutgoingRule6 = _wrapIptables(`sudo ip6tables -w -t nat ${ops} FW_NAT_BLOCK ${matchMacSrc} -m set --match-set ${dstSet6} dst -j FW_NAT_HOLE`)
-
-    await exec(cmdOutgoingRule);
-    await exec(cmdIncomingRule);
-    await exec(cmdOutgoingRule6);
-    await exec(cmdIncomingRule6);
-    await exec(cmdNatOutgoingRule);
-    await exec(cmdNatOutgoingRule6);
-
-    if (destroy) {
-      if (macTag) {
-        await Ipset.destroy(macSet)
-      }
-      if (destroyDstCache) {
-        await Ipset.destroy(dstSet)
-        await Ipset.destroy(dstSet6)
-      }
-    }
-
-    log.info('Finish', destroy ? 'destroying' : 'creating', 'block environment for', macTag || "null", dstTag);
-
-  } catch(err) {
-    log.error('Error when setup blocking env', err);
-  }
 }
 
 async function setupCategoryEnv(category, dstType = "hash:ip") {
@@ -286,82 +138,110 @@ function unblock(target, ipset, whitelist = false) {
   return setupIpset(target, ipset, whitelist, true)
 }
 
-async function setupIpset(target, ipset, whitelist, remove = false) {
-  const slashIndex = target.indexOf('/')
-  const ipAddr = slashIndex > 0 ? target.substring(0, slashIndex) : target;
-
-  // default ipsets
-  if (!ipset) {
-    const prefix = whitelist ? 'whitelist' : 'blocked'
-    const type = slashIndex > 0 ? 'net' : 'ip';
-    ipset = `${prefix}_${type}_set`
-  }
+function setupIpset(target, ipset, whitelist, remove = false) {
+  const ipSpliterIndex = target.search(/[/,:]/)
+  const ipAddr = ipSpliterIndex > 0 ? target.substring(0, ipSpliterIndex) : target;
 
   // check and add v6 suffix
-  let suffix = '';
-  if (iptool.isV4Format(ipAddr)) {
+  if (ipAddr.match(/^\d+(-\d+)?/)) {
+    // ports
+  } else if (iptool.isV4Format(ipAddr)) {
     // ip.isV6Format() will return true on v4 addresses
+    // ip.isV6Format() will return true for number 
+    // TODO: we should consider deprecate ip library
   } else if (iptool.isV6Format(ipAddr)) {
-    suffix = '6'
-  } else {
-    // do nothing
+    ipset = ipset + '6';
+  } 
+
+  const action = remove ? Ipset.del : Ipset.add;
+
+  log.info('setupIpset', action.constructor.name, ipset, target)
+
+  action(ipset, target)
+}
+
+async function setupRules(macTag, dstTag, dstType, allow = false, destroy = false, destroyDstCache = true) {
+  if (!dstTag) {
     return;
   }
-  ipset = ipset + suffix;
 
-  const action = remove ? 'del' : 'add';
+  try {
+    log.info(destroy ? 'Destroying' : 'Creating', 'block environment for', macTag || "null", dstTag,
+      destroy && destroyDstCache ? "and ipset" : "");
 
-  const cmd = `${action} -! ${ipset} ${target}`
-  log.debug("Control:IPSET:Enqueue", cmd);
-  Ipset.enqueue(cmd);
-  return;
-}
+    const macSet = macTag ? getMacSet(macTag) : '';
+    const dstSet = getDstSet(dstTag)
+    // use same port set on both ip4 & ip6 rules
+    const dstSet6 = dstType == 'bitmap:port' ? dstSet : getDstSet6(dstTag)
 
-async function setupRules(macTag, dstTag, dstType, whitelist) {
-  if (whitelist) {
-    await setupWhitelistEnv(macTag, dstTag, dstType);
-  } else {
-    await setupBlockingEnv(macTag, dstTag, dstType);
+    if (!destroy) {
+      if (macTag) await Ipset.create(macSet, 'hash:mac')
+      await Ipset.create(dstSet, dstType)
+      if (dstType != 'bitmap:port')
+        await Ipset.create(dstSet6, dstType, false)
+    }
+
+
+    const filterChain = allow ? 'FW_WHITELIST' : 'FW_BLOCK'
+    const filterDest = allow ? 'RETURN' : 'FW_DROP'
+    const natChain = allow ? 'FW_NAT_WHITELIST' : 'FW_NAT_BLOCK'
+    const natDest = allow ? 'RETURN' : 'FW_NAT_HOLE'
+
+    const outRule     = new Rule().chn(filterChain).mth(dstSet, 'dst').jmp(filterDest)
+    const outRule6    = new Rule().chn(filterChain).mth(dstSet6, 'dst').jmp(filterDest).fam(6)
+    const natOutRule  = new Rule('nat').chn(natChain).mth(dstSet, 'dst').jmp(natDest)
+    const natOutRule6 = new Rule('nat').chn(natChain).mth(dstSet6, 'dst').jmp(natDest).fam(6)
+
+    // matching MAC addr won't work in opposite direction
+    if (macTag) {
+      outRule.mth(macSet, 'src')
+      outRule6.mth(macSet, 'src')
+      natOutRule.mth(macSet, 'src')
+      natOutRule6.mth(macSet, 'src')
+    }
+
+    const op = destroy ? '-D' : '-I'
+    await exec(outRule.toCmd(op)) 
+    await exec(outRule6.toCmd(op)) 
+    await exec(natOutRule.toCmd(op)) 
+    await exec(natOutRule6.toCmd(op)) 
+
+
+    if (destroy) {
+      if (macTag) {
+        await Ipset.destroy(macSet)
+      }
+      if (destroyDstCache) {
+        await Ipset.destroy(dstSet)
+        if (dstType != 'bitmap:port')
+          await Ipset.destroy(dstSet6)
+      }
+    }
+
+    log.info('Finish', destroy ? 'destroying' : 'creating', 'block environment for', macTag || "null", dstTag);
+
+  } catch(err) {
+    log.error('Error when setup blocking env', err);
   }
 }
 
-async function addMacToSet(macTag, macAddresses) {
+function destroyRules(macTag, dstTag, whitelist, destroyDstCache = true) {
+  return setupRules(macTag, dstTag, null, whitelist, true, destroyDstCache)
+}
+
+async function addMacToSet(macAddresses, ipset = null, whitelist = false) {
+  ipset = ipset || (whitelist ? 'blocked_mac_set' : 'whitelist_mac_set')
+
   for (const mac of macAddresses || []) {
-    await advancedBlockMAC(mac, getMacSet(macTag));
+    await Ipset.add(ipset, mac);
   }
 }
 
-async function destroyRules(macTag, dstTag, whitelist, destroyDstCache = true) {
-  if (whitelist) {
-    await setupWhitelistEnv(macTag, dstTag, null, true, destroyDstCache);
-  } else {
-    await setupBlockingEnv(macTag, dstTag, null, true, destroyDstCache);
-  }
-}
+async function delMacFromSet(macAddresses, ipset = null, whitelist = false) {
+  ipset = ipset || (whitelist ? 'blocked_mac_set' : 'whitelist_mac_set')
 
-async function advancedBlockMAC(macAddress, setName) {
-  try {
-    if (macAddress && setName) {
-      const cmd = `sudo ipset add -! ${setName} ${macAddress}`
-      return exec(cmd)
-    } else {
-      throw new Error(`Mac ${macAddress} or Set ${setName} not exists`)
-    }
-  } catch(err) {
-    log.error('Error when advancedBlockMAC', err);
-  }
-}
-
-async function advancedUnblockMAC(macAddress, setName) {
-  try {
-    if (macAddress && setName) {
-      const cmd = `sudo ipset -! del ${setName} ${macAddress}`
-      return exec(cmd)
-    } else {
-      throw new Error(`Mac ${macAddress} or Set ${setName} not exists`)
-    }
-  } catch(err) {
-    log.error('Error when advancedUnblockMAC', err);
+  for (const mac of macAddresses || []) {
+    await Ipset.del(ipset, mac);
   }
 }
 
@@ -394,16 +274,13 @@ function blockPublicPort(localIPAddress, localPort, protocol, ipset) {
   log.info("Blocking public port:", localIPAddress, localPort, protocol, ipset);
   protocol = protocol || "tcp";
 
-  let entry = util.format("%s,%s:%s", localIPAddress, protocol, localPort);
-  let cmd = null;
+  const entry = util.format("%s,%s:%s", localIPAddress, protocol, localPort);
 
-  if(iptool.isV4Format(localIPAddress)) {
-    cmd = `sudo ipset add -! ${ipset} ${entry}`
-  } else {
-    cmd = `sudo ipset add -! ${ipset}6 ${entry}`
+  if(!iptool.isV4Format(localIPAddress)) {
+    ipset = ipset + '6'
   }
 
-  return exec(cmd);
+  return Ipset.add(ipset, entry)
 }
 
 function unblockPublicPort(localIPAddress, localPort, protocol, ipset) {
@@ -412,16 +289,14 @@ function unblockPublicPort(localIPAddress, localPort, protocol, ipset) {
   protocol = protocol || "tcp";
 
   let entry = util.format("%s,%s:%s", localIPAddress, protocol, localPort);
-  let cmd = null;
 
-  if(iptool.isV4Format(localIPAddress)) {
-    cmd = `sudo ipset del -! ${ipset} ${entry}`
-  } else {
-    cmd = `sudo ipset del -! ${ipset}6 ${entry}`
+  if(!iptool.isV4Format(localIPAddress)) {
+    ipset = ipset + '6'
   }
 
-  return exec(cmd);
+  return Ipset.del(ipset, entry)
 }
+
 
 module.exports = {
   setupBlockChain:setupBlockChain,
@@ -433,13 +308,12 @@ module.exports = {
   setupRules: setupRules,
   destroyRules: destroyRules,
   addMacToSet: addMacToSet,
+  delMacFromSet: delMacFromSet,
   blockPublicPort:blockPublicPort,
   unblockPublicPort: unblockPublicPort,
-  setupBlockingEnv: setupBlockingEnv,
   getDstSet: getDstSet,
   getDstSet6: getDstSet6,
   getMacSet: getMacSet,
   existsBlockingEnv: existsBlockingEnv,
-  enableGlobalWhitelist: enableGlobalWhitelist,
-  disableGlobalWhitelist: disableGlobalWhitelist
+  setupGlobalWhitelist: setupGlobalWhitelist
 }

--- a/control/CountryUpdater.js
+++ b/control/CountryUpdater.js
@@ -35,7 +35,6 @@ const iptool = require("ip");
 const util = require('util')
 const fs = require('fs');
 const writeFileAsync = util.promisify(fs.writeFile);
-const readFileAsync = util.promisify(fs.readFile);
 
 const Ipset = require('../net2/Ipset.js')
 

--- a/control/install_iptables_setup.sh
+++ b/control/install_iptables_setup.sh
@@ -15,16 +15,23 @@ sudo ipset create blocked_ip_set hash:ip family inet hashsize 128 maxelem 65536 
 sudo ipset create blocked_domain_set hash:ip family inet hashsize 128 maxelem 65536 &>/dev/null
 sudo ipset create blocked_net_set hash:net family inet hashsize 128 maxelem 65536 &>/dev/null
 sudo ipset create blocked_ip_port_set hash:ip,port family inet hashsize 128 maxelem 65536 &>/dev/null
+sudo ipset create blocked_remote_ip_port_set hash:ip,port family inet hashsize 128 maxelem 65536 &>/dev/null
+sudo ipset create blocked_remote_net_port_set hash:net,port family inet hashsize 128 maxelem 65536 &>/dev/null
+sudo ipset create blocked_remote_port_set bitmap:port range 0-65535 &>/dev/null
 sudo ipset create blocked_mac_set hash:mac &>/dev/null
 sudo ipset create trusted_ip_set hash:net family inet hashsize 128 maxelem 65536 &> /dev/null
 sudo ipset create monitored_ip_set hash:ip family inet hashsize 128 maxelem 65536 &> /dev/null
 sudo ipset create devicedns_mac_set hash:mac &>/dev/null
 sudo ipset create protected_ip_set hash:ip family inet hashsize 128 maxelem 65536 &> /dev/null
+sudo ipset create device_whitelist_set hash:mac &> /dev/null
 sudo ipset create whitelist_ip_set hash:ip family inet hashsize 128 maxelem 65536 &> /dev/null
 sudo ipset create whitelist_domain_set hash:ip family inet hashsize 128 maxelem 65536 &> /dev/null
 sudo ipset create whitelist_net_set hash:ip family inet hashsize 128 maxelem 65536 &> /dev/null
 sudo ipset create whitelist_ip_port_set hash:ip,port family inet hashsize 128 maxelem 65535 &>/dev/null
+sudo ipset create whitelist_remote_ip_port_set hash:ip,port family inet hashsize 128 maxelem 65536 &>/dev/null
+sudo ipset create whitelist_remote_net_port_set hash:net,port family inet hashsize 128 maxelem 65536 &>/dev/null
 sudo ipset create whitelist_mac_set hash:mac &>/dev/null
+sudo ipset create whitelist_remote_port_set bitmap:port range 0-65535 &>/dev/null
 sudo ipset create no_dns_caching_mac_set hash:mac &>/dev/null
 
 # This is to ensure all ipsets are empty when initializing
@@ -32,6 +39,9 @@ sudo ipset flush blocked_ip_set
 sudo ipset flush blocked_domain_set
 sudo ipset flush blocked_net_set
 sudo ipset flush blocked_ip_port_set
+sudo ipset flush blocked_remote_ip_port_set
+sudo ipset flush blocked_remote_net_port_set
+sudo ipset flush blocked_remote_port_set
 sudo ipset flush blocked_mac_set
 sudo ipset flush trusted_ip_set
 sudo ipset flush monitored_ip_set
@@ -41,6 +51,9 @@ sudo ipset flush whitelist_ip_set
 sudo ipset flush whitelist_domain_set
 sudo ipset flush whitelist_net_set
 sudo ipset flush whitelist_ip_port_set
+sudo ipset flush whitelist_remote_ip_port_set
+sudo ipset flush whitelist_remote_net_port_set
+sudo ipset flush whitelist_remote_port_set
 sudo ipset flush whitelist_mac_set
 sudo ipset flush no_dns_caching_mac_set
 
@@ -66,70 +79,85 @@ sudo ip rule add pref 32767 from all lookup default
 sudo iptables -w -N FW_DROP &>/dev/null
 sudo iptables -w -F FW_DROP
 sudo iptables -w -C FW_DROP -p tcp -j REJECT &>/dev/null || sudo iptables -w -A FW_DROP -p tcp -j REJECT
-sudo iptables -w -C FW_DROP -p all -j DROP &>/dev/null || sudo iptables -w -A FW_DROP -p all -j DROP
+sudo iptables -w -C FW_DROP -j DROP &>/dev/null || sudo iptables -w -A FW_DROP -j DROP
 
 #FIXME: ignore if failed or not
 sudo iptables -w -N FW_BLOCK &>/dev/null
 sudo iptables -w -F FW_BLOCK
 
 # return everything
-sudo iptables -w -C FW_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null || sudo iptables -w -A FW_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
+sudo iptables -w -C FW_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null || sudo iptables -w -A FW_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
 
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_ip_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_ip_set dst -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_ip_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_ip_set src -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_domain_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_domain_set dst -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_domain_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_domain_set src -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_net_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_net_set dst -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_net_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_net_set src -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_ip_port_set dst,dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_ip_port_set dst,dst -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_mac_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_mac_set dst -j FW_DROP
-sudo iptables -w -C FW_BLOCK -p all -m set --match-set blocked_mac_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -p all -m set --match-set blocked_mac_set src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_ip_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_ip_set dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_ip_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_ip_set src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_domain_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_domain_set dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_domain_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_domain_set src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_net_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_net_set dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_net_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_net_set src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_ip_port_set dst,dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_ip_port_set dst,dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_ip_port_set src,src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_ip_port_set src,src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_remote_ip_port_set dst,dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_remote_ip_port_set dst,dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_remote_ip_port_set src,src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_remote_ip_port_set src,src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_remote_net_port_set dst,dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_remote_net_port_set dst,dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_remote_net_port_set src,src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_remote_net_port_set src,src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_remote_port_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_remote_port_set src -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_mac_set dst -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_mac_set dst -j FW_DROP
+sudo iptables -w -C FW_BLOCK -m set --match-set blocked_mac_set src -j FW_DROP &>/dev/null || sudo iptables -w -I FW_BLOCK -m set --match-set blocked_mac_set src -j FW_DROP
 
 # forward to fw_block
-sudo iptables -w -C FORWARD -p all -j FW_BLOCK &>/dev/null || sudo iptables -w -A FORWARD -p all -j FW_BLOCK
+sudo iptables -w -C FORWARD -j FW_BLOCK &>/dev/null || sudo iptables -w -A FORWARD -j FW_BLOCK
 
-# clear whitelist mark on dns packet in mangle table
-sudo iptables -w -t mangle -C PREROUTING -p tcp -m tcp --dport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p tcp -m tcp --dport 53 -j CONNMARK --set-xmark 0x0/0x1
-sudo iptables -w -t mangle -C PREROUTING -p tcp -m tcp --sport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p tcp -m tcp --sport 53 -j CONNMARK --set-xmark 0x0/0x1
-sudo iptables -w -t mangle -C PREROUTING -p udp -m udp --dport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p udp -m udp --dport 53 -j CONNMARK --set-xmark 0x0/0x1
-sudo iptables -w -t mangle -C PREROUTING -p udp -m udp --sport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p udp -m udp --sport 53 -j CONNMARK --set-xmark 0x0/0x1
-# clear whitelist mark on dhcp packet in mangle table
-sudo iptables -w -t mangle -C PREROUTING -p tcp -m tcp --dport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p tcp -m tcp --dport 67 -j CONNMARK --set-xmark 0x0/0x1
-sudo iptables -w -t mangle -C PREROUTING -p tcp -m tcp --sport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p tcp -m tcp --sport 67 -j CONNMARK --set-xmark 0x0/0x1
-sudo iptables -w -t mangle -C PREROUTING -p udp -m udp --dport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p udp -m udp --dport 67 -j CONNMARK --set-xmark 0x0/0x1
-sudo iptables -w -t mangle -C PREROUTING -p udp -m udp --sport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -p udp -m udp --sport 67 -j CONNMARK --set-xmark 0x0/0x1
-# clear whitelist mark on local subnet traffic in mangle table
-sudo iptables -w -t mangle -C PREROUTING -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j CONNMARK --set-xmark 0x0/0x1
-# clear whitelist mark on established connections in mangle table
-sudo iptables -w -t mangle -C PREROUTING -m conntrack --ctstate RELATED,ESTABLISHED -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo iptables -w -t mangle -A PREROUTING -m conntrack --ctstate RELATED,ESTABLISHED -j CONNMARK --set-xmark 0x0/0x1
+
+sudo iptables -w -N FW_WHITELIST_PREROUTE &> /dev/null
+sudo iptables -w -F FW_WHITELIST_PREROUTE
+
+sudo iptables -w -C FW_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN
+sudo iptables -w -C FW_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN
+
+# skip whitelist for local subnet traffic
+sudo iptables -w -C FW_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN
+
+# FIXME: why??
+sudo iptables -w -C FW_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+
 
 sudo iptables -w -N FW_WHITELIST &> /dev/null
 sudo iptables -w -F FW_WHITELIST
 
+# device level whitelist
+sudo iptables -w -C FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST &>/dev/null || sudo iptables -w -A FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST
+
+
 # return if src/dst is in whitelist
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_ip_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_ip_set src -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_ip_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_ip_set dst -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_domain_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_domain_set src -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_domain_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_domain_set dst -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_net_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_net_set src -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_net_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_net_set dst -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_ip_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_ip_port_set dst,dst -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN
-sudo iptables -w -C FW_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_ip_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_ip_set src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_ip_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_ip_set dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_domain_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_domain_set src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_domain_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_domain_set dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_net_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_net_set src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_net_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_net_set dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_ip_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_ip_port_set dst,dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_ip_port_set src,src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_ip_port_set src,src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -I FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set dst,dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set src,src -j RETURN &>/dev/null || sudo iptables -w -I FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set src,src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_remote_net_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -I FW_WHITELIST -m set --match-set whitelist_remote_net_port_set dst,dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_remote_net_port_set src,src -j RETURN &>/dev/null || sudo iptables -w -I FW_WHITELIST -m set --match-set whitelist_remote_net_port_set src,src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN &>/dev/null || sudo iptables -w -I FW_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN &>/dev/null || sudo iptables -w -I FW_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN
+sudo iptables -w -C FW_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo iptables -w -A FW_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN
 
 # reject tcp
 sudo iptables -w -C FW_WHITELIST -p tcp --source 0.0.0.0/0 --destination 0.0.0.0/0 -j REJECT &>/dev/null || sudo iptables -w -A FW_WHITELIST -p tcp --source 0.0.0.0/0 --destination 0.0.0.0/0 -j REJECT
 # drop everything
-sudo iptables -w -C FW_WHITELIST -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo iptables -w -A FW_WHITELIST -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
+sudo iptables -w -C FW_WHITELIST --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo iptables -w -A FW_WHITELIST --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
 
-# divert to whitelist chain if whitelist bit is marked
-sudo iptables -w -C FORWARD -m connmark --mark 0x1/0x1 -j FW_WHITELIST &>/dev/null || sudo iptables -w -I FORWARD -m connmark --mark 0x1/0x1 -j FW_WHITELIST
 
 sudo iptables -w -N FW_SHIELD &> /dev/null
 sudo iptables -w -F FW_SHIELD
 
 # drop everything
-sudo iptables -w -C FW_SHIELD -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo iptables -w -A FW_SHIELD -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
+sudo iptables -w -C FW_SHIELD --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo iptables -w -A FW_SHIELD --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
 
 # return established and related connections
 sudo iptables -w -C FW_SHIELD -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN &>/dev/null || sudo iptables -w -I FW_SHIELD -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
@@ -139,6 +167,8 @@ sudo iptables -w -C FW_SHIELD -m set --match-set trusted_ip_set src -j RETURN &>
 
 # divert to shield chain if dst ip is in protected_ip_set
 sudo iptables -w -C FORWARD -m set --match-set protected_ip_set dst -j FW_SHIELD &>/dev/null || sudo iptables -w -A FORWARD -m set --match-set protected_ip_set dst -j FW_SHIELD
+
+
 
 # nat blackhole 8888
 sudo iptables -w -t nat -N FW_NAT_HOLE &>/dev/null
@@ -158,35 +188,63 @@ sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_domain_set ds
 sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_domain_set src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_domain_set src -j FW_NAT_HOLE
 sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_net_set dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_net_set dst -j FW_NAT_HOLE
 sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_net_set src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_net_set src -j FW_NAT_HOLE
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_ip_port_set dst,dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_ip_port_set dst,dst -j FW_NAT_HOLE &>/dev/null
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_ip_port_set src,src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_ip_port_set src,src -j FW_NAT_HOLE &>/dev/null
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set dst,dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set dst,dst -j FW_NAT_HOLE
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set src,src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set src,src -j FW_NAT_HOLE
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set dst,dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set dst,dst -j FW_NAT_HOLE
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set src,src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set src,src -j FW_NAT_HOLE
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_NAT_HOLE
+sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_port_set src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_port_set src -j FW_NAT_HOLE
 sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_mac_set dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_mac_set dst -j FW_NAT_HOLE
 sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_mac_set src -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_mac_set src -j FW_NAT_HOLE
-sudo iptables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_ip_port_set dst,dst -j FW_NAT_HOLE &>/dev/null || sudo iptables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_ip_port_set dst,dst -j FW_NAT_HOLE &>/dev/null
 
 
-sudo iptables -w -t nat -C FW_NAT_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null ||   sudo iptables -w -t nat -A FW_NAT_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
+sudo iptables -w -t nat -C FW_NAT_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null ||   sudo iptables -w -t nat -A FW_NAT_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
 
 sudo iptables -w -t nat -C PREROUTING -j FW_NAT_BLOCK &>/dev/null || sudo iptables -w -t nat -I PREROUTING -j FW_NAT_BLOCK
+
+sudo iptables -w -t nat -N FW_NAT_WHITELIST_PREROUTE &> /dev/null
+sudo iptables -w -t nat -F FW_NAT_WHITELIST_PREROUTE
+
+sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN
+
+# skip whitelist for local subnet traffic
+sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN
+
+# FIXME: why??
+sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
 
 sudo iptables -w -t nat -N FW_NAT_WHITELIST &>/dev/null
 sudo iptables -w -t nat -F FW_NAT_WHITELIST
 
+# device level whitelist
+sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST
+
+
 # return if src/dst is in whitelist
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set src -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set dst -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set src -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set dst -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set src -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set dst -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_port_set dst,dst -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN
-sudo iptables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_set src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_set dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_domain_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_domain_set src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_domain_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_domain_set dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_net_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_net_set src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_net_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_net_set dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set dst,dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set src,src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set src,src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -t nat -I FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set dst,dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set src,src -j RETURN &>/dev/null || sudo iptables -w -t nat -I FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set src,src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set dst,dst -j RETURN &>/dev/null || sudo iptables -w -t nat -I FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set dst,dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set src,src -j RETURN &>/dev/null || sudo iptables -w -t nat -I FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set src,src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -I FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -I FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN
+sudo iptables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN
 
 # redirect tcp udp to port 8888 by default
 sudo iptables -w -t nat -C FW_NAT_WHITELIST -p tcp -j REDIRECT --to-ports 8888 &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p tcp -j REDIRECT --to-ports 8888
 sudo iptables -w -t nat -C FW_NAT_WHITELIST -p udp -j REDIRECT --to-ports 8888 &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST -p udp -j REDIRECT --to-ports 8888
 
-# divert to whitelist chain if whitelist bit is marked
-sudo iptables -w -t nat -C PREROUTING -m connmark --mark 0x1/0x1 -j FW_NAT_WHITELIST &>/dev/null || sudo iptables -w -t nat -I PREROUTING -m connmark --mark 0x1/0x1 -j FW_NAT_WHITELIST
 
 # create dns redirect chain in PREROUTING
 sudo iptables -w -t nat -N PREROUTING_DNS_DEFAULT &> /dev/null
@@ -203,7 +261,7 @@ sudo iptables -w -t nat -F PREROUTING_DNS_VPN_CLIENT
 sudo iptables -w -t nat -C PREROUTING -j PREROUTING_DNS_VPN_CLIENT || sudo iptables -w -t nat -I PREROUTING -j PREROUTING_DNS_VPN_CLIENT
 
 if [[ -e /.dockerenv ]]; then
-  sudo iptables -w -C OUTPUT -p all -j FW_BLOCK &>/dev/null || sudo iptables -w -A OUTPUT -p all -j FW_BLOCK
+  sudo iptables -w -C OUTPUT -j FW_BLOCK &>/dev/null || sudo iptables -w -A OUTPUT -j FW_BLOCK
 fi
 
 if [[ -e /sbin/ip6tables ]]; then
@@ -212,6 +270,8 @@ if [[ -e /sbin/ip6tables ]]; then
   sudo ipset create blocked_domain_set6 hash:ip family inet6 hashsize 128 maxelem 65536 &>/dev/null
   sudo ipset create blocked_net_set6 hash:net family inet6 hashsize 128 maxelem 65536 &>/dev/null
   sudo ipset create blocked_ip_port_set6 hash:ip,port family inet6 hashsize 128 maxelem 65536 &>/dev/null
+  sudo ipset create blocked_remote_ip_port_set6 hash:ip,port family inet6 hashsize 128 maxelem 65536 &>/dev/null
+  sudo ipset create blocked_remote_net_port_set6 hash:net,port family inet6 hashsize 128 maxelem 65536 &>/dev/null
   sudo ipset create trusted_ip_set6 hash:ip family inet6 hashsize 128 maxelem 65536 &>/dev/null
   sudo ipset create monitored_ip_set6 hash:ip family inet6 hashsize 128 maxelem 65536 &>/dev/null
   sudo ipset create protected_ip_set6 hash:ip family inet6 hashsize 128 maxelem 65536 &>/dev/null
@@ -219,12 +279,16 @@ if [[ -e /sbin/ip6tables ]]; then
   sudo ipset create whitelist_domain_set6 hash:ip family inet6 hashsize 128 maxelem 65536 &> /dev/null
   sudo ipset create whitelist_net_set6 hash:ip family inet6 hashsize 128 maxelem 65536 &> /dev/null
   sudo ipset create whitelist_ip_port_set6 hash:ip,port family inet6 hashsize 128 maxelem 65536 &>/dev/null
+  sudo ipset create whitelist_remote_ip_port_set6 hash:ip,port family inet6 hashsize 128 maxelem 65536 &>/dev/null
+  sudo ipset create whitelist_remote_net_port_set6 hash:net,port family inet6 hashsize 128 maxelem 65536 &>/dev/null
 
 
   sudo ipset flush blocked_ip_set6
   sudo ipset flush blocked_domain_set6
   sudo ipset flush blocked_net_set6
   sudo ipset flush blocked_ip_port_set6
+  sudo ipset flush blocked_remote_ip_port_set6
+  sudo ipset flush blocked_remote_net_port_set6
   sudo ipset flush trusted_ip_set6
   sudo ipset flush monitored_ip_set6
   sudo ipset flush protected_ip_set6
@@ -232,76 +296,90 @@ if [[ -e /sbin/ip6tables ]]; then
   sudo ipset flush whitelist_domain_set6
   sudo ipset flush whitelist_net_set6
   sudo ipset flush whitelist_ip_port_set6
+  sudo ipset flush whitelist_remote_ip_port_set6
+  sudo ipset flush whitelist_remote_net_port_set6
 
   # multi protocol block chain
   sudo ip6tables -w -N FW_DROP &>/dev/null
   sudo ip6tables -w -F FW_DROP
   sudo ip6tables -w -C FW_DROP -p tcp -j REJECT &>/dev/null || sudo ip6tables -w -A FW_DROP -p tcp -j REJECT
-  sudo ip6tables -w -C FW_DROP -p all -j DROP &>/dev/null || sudo ip6tables -w -A FW_DROP -p all -j DROP
+  sudo ip6tables -w -C FW_DROP -j DROP &>/dev/null || sudo ip6tables -w -A FW_DROP -j DROP
 
 
   sudo ip6tables -w -N FW_BLOCK &>/dev/null
   sudo ip6tables -w -F FW_BLOCK
 
   # return everything
-  sudo ip6tables -w -C FW_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null ||   sudo ip6tables -w -A FW_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
+  sudo ip6tables -w -C FW_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null ||   sudo ip6tables -w -A FW_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
 
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_ip_set6 dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_ip_set6 dst -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_ip_set6 src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_ip_set6 src -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_domain_set6 dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_domain_set6 dst -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_domain_set6 src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_domain_set6 src -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_net_set6 dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_net_set6 dst -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_net_set6 src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_net_set6 src -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_ip_port_set6 dst,dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_ip_port_set6 dst,dst -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_mac_set dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_mac_set dst -j FW_DROP
-  sudo ip6tables -w -C FW_BLOCK -p all -m set --match-set blocked_mac_set src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -p all -m set --match-set blocked_mac_set src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_ip_set6 dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_ip_set6 dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_ip_set6 src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_ip_set6 src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_domain_set6 dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_domain_set6 dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_domain_set6 src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_domain_set6 src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_net_set6 dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_net_set6 dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_net_set6 src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_net_set6 src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_ip_port_set6 dst,dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_ip_port_set6 dst,dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_ip_port_set6 src,src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_ip_port_set6 src,src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_remote_ip_port_set6 dst,dst -j FW_DROP &>/dev/null || sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_remote_ip_port_set6 dst,dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_remote_ip_port_set6 src,src -j FW_DROP &>/dev/null || sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_remote_ip_port_set6 src,src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_remote_net_port_set6 dst,dst -j FW_DROP &>/dev/null || sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_remote_net_port_set6 dst,dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_remote_net_port_set6 src,src -j FW_DROP &>/dev/null || sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_remote_net_port_set6 src,src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_remote_port_set src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_remote_port_set src -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_mac_set dst -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_mac_set dst -j FW_DROP
+  sudo ip6tables -w -C FW_BLOCK -m set --match-set blocked_mac_set src -j FW_DROP &>/dev/null ||   sudo ip6tables -w -I FW_BLOCK -m set --match-set blocked_mac_set src -j FW_DROP
   
   # forward to fw_block
-  sudo ip6tables -w -C FORWARD -p all -j FW_BLOCK &>/dev/null ||   sudo ip6tables -w -A FORWARD -p all -j FW_BLOCK
+  sudo ip6tables -w -C FORWARD -j FW_BLOCK &>/dev/null ||   sudo ip6tables -w -A FORWARD -j FW_BLOCK
 
-  # clear whitelist mark on dns packet in mangle table
-  sudo ip6tables -w -t mangle -C PREROUTING -p tcp -m tcp --dport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p tcp -m tcp --dport 53 -j CONNMARK --set-xmark 0x0/0x1
-  sudo ip6tables -w -t mangle -C PREROUTING -p tcp -m tcp --sport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p tcp -m tcp --sport 53 -j CONNMARK --set-xmark 0x0/0x1
-  sudo ip6tables -w -t mangle -C PREROUTING -p udp -m udp --dport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p udp -m udp --dport 53 -j CONNMARK --set-xmark 0x0/0x1
-  sudo ip6tables -w -t mangle -C PREROUTING -p udp -m udp --sport 53 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p udp -m udp --sport 53 -j CONNMARK --set-xmark 0x0/0x1
-  # clear whitelist mark on dhcp packet in mangle table
-  sudo ip6tables -w -t mangle -C PREROUTING -p tcp -m tcp --dport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p tcp -m tcp --dport 67 -j CONNMARK --set-xmark 0x0/0x1
-  sudo ip6tables -w -t mangle -C PREROUTING -p tcp -m tcp --sport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p tcp -m tcp --sport 67 -j CONNMARK --set-xmark 0x0/0x1
-  sudo ip6tables -w -t mangle -C PREROUTING -p udp -m udp --dport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p udp -m udp --dport 67 -j CONNMARK --set-xmark 0x0/0x1
-  sudo ip6tables -w -t mangle -C PREROUTING -p udp -m udp --sport 67 -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -p udp -m udp --sport 67 -j CONNMARK --set-xmark 0x0/0x1
-  # clear whitelist mark on local subnet packet in mangle table
-  sudo ip6tables -w -t mangle -C PREROUTING -m set --match-set trusted_ip_set6 src -m set --match-set trusted_ip_set6 dst -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -m set --match-set trusted_ip_set6 src -m set --match-set trusted_ip_set6 dst -j CONNMARK --set-xmark 0x0/0x1
-  # clear whitelist mark on established connections in mangle table
-  sudo ip6tables -w -t mangle -C PREROUTING -m conntrack --ctstate RELATED,ESTABLISHED -j CONNMARK --set-xmark 0x0/0x1 &>/dev/null || sudo ip6tables -w -t mangle -A PREROUTING -m conntrack --ctstate RELATED,ESTABLISHED -j CONNMARK --set-xmark 0x0/0x1
+  sudo ip6tables -w -N FW_WHITELIST_PREROUTE &> /dev/null
+  sudo ip6tables -w -F FW_WHITELIST_PREROUTE
+
+  sudo ip6tables -w -C FW_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN
+
+  # skip whitelist for local subnet traffic
+  sudo ip6tables -w -C FW_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN
+
+  # FIXME: why??
+  sudo ip6tables -w -C FW_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
 
   sudo ip6tables -w -N FW_WHITELIST &> /dev/null
   sudo ip6tables -w -F FW_WHITELIST
 
+  # device level whitelist
+  sudo ip6tables -w -C FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST &>/dev/null || sudo ip6tables -w -A FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST
+
+
   # return if src/dst is in whitelist
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_ip_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_ip_set6 src -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_ip_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_ip_set6 dst -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_domain_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_domain_set6 src -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_domain_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_domain_set6 dst -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_net_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_net_set6 src -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_net_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_net_set6 dst -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN
-  sudo ip6tables -w -C FW_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_ip_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_ip_set6 src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_ip_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_ip_set6 dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_domain_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_domain_set6 src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_domain_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_domain_set6 dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_net_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_net_set6 src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_net_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_net_set6 dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_ip_port_set6 src,src -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_ip_port_set6 src,src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 dst,dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 src,src -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 src,src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_remote_net_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_remote_net_port_set6 dst,dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_remote_net_port_set6 src,src -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_remote_net_port_set6 src,src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN &>/dev/null || sudo ip6tables -w -I FW_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN
+  sudo ip6tables -w -C FW_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN
 
   # reject tcp
   sudo ip6tables -w -C FW_WHITELIST -p tcp --source 0.0.0.0/0 --destination 0.0.0.0/0 -j REJECT &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p tcp --source 0.0.0.0/0 --destination 0.0.0.0/0 -j REJECT
   # drop everything
-  sudo ip6tables -w -C FW_WHITELIST -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo ip6tables -w -A FW_WHITELIST -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
-
-  # divert to white list chain if whitelist bit is marked
-  sudo ip6tables -w -C FORWARD -m connmark --mark 0x1/0x1 -j FW_WHITELIST &>/dev/null || sudo ip6tables -w -I FORWARD -m connmark --mark 0x1/0x1 -j FW_WHITELIST
+  sudo ip6tables -w -C FW_WHITELIST --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo ip6tables -w -A FW_WHITELIST --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
 
 
   sudo ip6tables -w -N FW_SHIELD &> /dev/null
   sudo ip6tables -w -F FW_SHIELD
 
   # drop everything
-  sudo ip6tables -w -C FW_SHIELD -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo ip6tables -w -A FW_SHIELD -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
+  sudo ip6tables -w -C FW_SHIELD --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP &>/dev/null || sudo ip6tables -w -A FW_SHIELD --source 0.0.0.0/0 --destination 0.0.0.0/0 -j DROP
 
   # return established and related connections
   sudo ip6tables -w -C FW_SHIELD -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN &>/dev/null || sudo ip6tables -w -I FW_SHIELD -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
@@ -330,34 +408,62 @@ if [[ -e /sbin/ip6tables ]]; then
   sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_domain_set6 src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_domain_set6 src -j FW_NAT_HOLE
   sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_net_set6 dst -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_net_set6 dst -j FW_NAT_HOLE
   sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_net_set6 src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_net_set6 src -j FW_NAT_HOLE
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set6 dst,dst -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set6 dst,dst -j FW_NAT_HOLE
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set6 src,src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_ip_port_set6 src,src -j FW_NAT_HOLE
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set6 dst,dst -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set6 dst,dst -j FW_NAT_HOLE
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set6 src,src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_net_port_set6 src,src -j FW_NAT_HOLE
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_port_set dst -j FW_NAT_HOLE
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_remote_port_set src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_remote_port_set src -j FW_NAT_HOLE
   sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_mac_set dst -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_mac_set dst -j FW_NAT_HOLE
   sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_mac_set src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_mac_set src -j FW_NAT_HOLE
   sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_ip_port_set6 dst,dst -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_ip_port_set6 dst,dst -j FW_NAT_HOLE &>/dev/null
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -m set --match-set blocked_ip_port_set6 src,src -j FW_NAT_HOLE &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_BLOCK -m set --match-set blocked_ip_port_set6 src,src -j FW_NAT_HOLE &>/dev/null
 
-  sudo ip6tables -w -t nat -C FW_NAT_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null ||   sudo ip6tables -w -t nat -A FW_NAT_BLOCK -p all --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN &>/dev/null ||   sudo ip6tables -w -t nat -A FW_NAT_BLOCK --source 0.0.0.0/0 --destination 0.0.0.0/0 -j RETURN
 
   sudo ip6tables -w -t nat -C PREROUTING -j FW_NAT_BLOCK &>/dev/null || sudo ip6tables -w -t nat -I PREROUTING -j FW_NAT_BLOCK
+
+  sudo ip6tables -w -t nat -N FW_NAT_WHITELIST_PREROUTE &> /dev/null
+  sudo ip6tables -w -t nat -F FW_NAT_WHITELIST_PREROUTE
+
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -p tcp -m multiport --ports 53,67 -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -p udp -m multiport --ports 53,67 -j RETURN
+
+  # skip whitelist for local subnet traffic
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m set --match-set trusted_ip_set src -m set --match-set trusted_ip_set dst -j RETURN
+
+  # FIXME: why??
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+
 
   sudo ip6tables -w -t nat -N FW_NAT_WHITELIST &>/dev/null
   sudo ip6tables -w -t nat -F FW_NAT_WHITELIST
 
+  # device level whitelist
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST
+
+
   # return if src/dst is in whitelist
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set6 src -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_set6 dst -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set6 src -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_domain_set6 dst -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set6 src -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_net_set6 dst -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set dst -j RETURN
-  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p all -m set --match-set whitelist_mac_set src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_set6 src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_set6 dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_domain_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_domain_set6 src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_domain_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_domain_set6 dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_net_set6 src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_net_set6 src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_net_set6 dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_net_set6 dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set6 dst,dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set6 src,src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_ip_port_set6 src,src -j RETURN &>/dev/null
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 dst,dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 src,src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_remote_ip_port_set6 src,src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set6 dst,dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set6 dst,dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set6 src,src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_remote_net_port_set6 src,src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_remote_port_set src -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_mac_set dst -j RETURN
+  sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -m set --match-set whitelist_mac_set src -j RETURN
 
   # redirect tcp udp to port 8888 by default
   sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p tcp -j REDIRECT --to-ports 8888 &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p tcp -j REDIRECT --to-ports 8888
   sudo ip6tables -w -t nat -C FW_NAT_WHITELIST -p udp -j REDIRECT --to-ports 8888 &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST -p udp -j REDIRECT --to-ports 8888
-
-  # divert to whitelist chain if whitelist chain is marked
-  sudo ip6tables -w -t nat -C PREROUTING -m connmark --mark 0x1/0x1 -j FW_NAT_WHITELIST &>/dev/null || sudo ip6tables -w -t nat -I PREROUTING -m connmark --mark 0x1/0x1 -j FW_NAT_WHITELIST
 
   # create dns redirect chain in PREROUTING
   sudo ip6tables -w -t nat -N PREROUTING_DNS_DEFAULT &> /dev/null

--- a/control/install_iptables_setup.sh
+++ b/control/install_iptables_setup.sh
@@ -125,6 +125,8 @@ sudo iptables -w -C FW_WHITELIST_PREROUTE -m conntrack --ctstate RELATED,ESTABLI
 sudo iptables -w -N FW_WHITELIST &> /dev/null
 sudo iptables -w -F FW_WHITELIST
 
+sudo iptables -w -C FORWARD -j FW_WHITELIST_PREROUTE &>/dev/null || sudo iptables -w -I FORWARD -j FW_WHITELIST_PREROUTE
+
 # device level whitelist
 sudo iptables -w -C FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST &>/dev/null || sudo iptables -w -A FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST
 
@@ -218,6 +220,8 @@ sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m conntrack --ctstate RELA
 
 sudo iptables -w -t nat -N FW_NAT_WHITELIST &>/dev/null
 sudo iptables -w -t nat -F FW_NAT_WHITELIST
+
+sudo iptables -w -t nat -C PREROUTING -j FW_NAT_WHITELIST_PREROUTE &>/dev/null || sudo iptables -w -t nat -I PREROUTING -j FW_NAT_WHITELIST_PREROUTE
 
 # device level whitelist
 sudo iptables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST &>/dev/null || sudo iptables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST
@@ -347,6 +351,8 @@ if [[ -e /sbin/ip6tables ]]; then
   sudo ip6tables -w -N FW_WHITELIST &> /dev/null
   sudo ip6tables -w -F FW_WHITELIST
 
+  sudo ip6tables -w -C FORWARD -j FW_WHITELIST_PREROUTE &>/dev/null || sudo ip6tables -w -I FORWARD -j FW_WHITELIST_PREROUTE
+
   # device level whitelist
   sudo ip6tables -w -C FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST &>/dev/null || sudo ip6tables -w -A FW_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_WHITELIST
 
@@ -438,6 +444,8 @@ if [[ -e /sbin/ip6tables ]]; then
 
   sudo ip6tables -w -t nat -N FW_NAT_WHITELIST &>/dev/null
   sudo ip6tables -w -t nat -F FW_NAT_WHITELIST
+
+  sudo ip6tables -w -t nat -C PREROUTING -j FW_NAT_WHITELIST_PREROUTE &>/dev/null || sudo ip6tables -w -t nat -I PREROUTING -j FW_NAT_WHITELIST_PREROUTE
 
   # device level whitelist
   sudo ip6tables -w -t nat -C FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST &>/dev/null || sudo ip6tables -w -t nat -A FW_NAT_WHITELIST_PREROUTE -m set --match-set device_whitelist_set src -j FW_NAT_WHITELIST

--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -531,6 +531,20 @@ class netBot extends ControllerBot {
     
   }
 
+  async _whitelist(ip, value, callback) {
+    if (ip === "0.0.0.0") {
+      await this.hostManager.loadPolicy()
+      await this.hostManager.setPolicyAsync("whitelist", value)
+    } else {
+      let host = await this.hostManager.getHostAsync(ip);
+
+      if (host != null) {
+        await host.loadPolicyAsync()
+        await host.setPolicyAsync("whitelist", value)
+      }
+    }
+  }
+
 
   _shadowsocks(ip, value, callback) {
     if(ip !== "0.0.0.0") {
@@ -1193,8 +1207,8 @@ class netBot extends ControllerBot {
     this.invalidateCache();
 
     if(extMgr.hasSet(msg.data.item)) {
-      async(() => {
-        const result = await (extMgr.set(msg.data.item, msg, msg.data.value))
+      (async () => {
+        const result = await extMgr.set(msg.data.item, msg, msg.data.value)
         this.simpleTxData(msg, result, null, callback)
       })().catch((err) => {
         this.simpleTxData(msg, null, err, callback)
@@ -1312,6 +1326,10 @@ class netBot extends ControllerBot {
               this._shield(msg.target, msg.data.value.shield, (err, obj) => {
                 cb(err);
               });
+              break;
+            case "whitelist":
+              this._whitelist(msg.target, msg.data.value.whitelist)
+                .then(cb).catch(cb)
               break;
           default:
             let target = msg.target

--- a/lib/Bone.js
+++ b/lib/Bone.js
@@ -784,16 +784,12 @@ exports.submitIntelFeedback = function (action, intel, data_type) {
   let type = intel['if.type'] || intel['type'];
   let target = intel['if.target'] || intel['target'];
 
-  switch (type) {
-  case 'dns':
-  case 'ip':
-  case 'devicePort':
-  case 'mac':
-  case 'category':
-      break;
-    default:
-      log.warn('Invalid action type: ' + type);
-      return;
+  if (!['dns', 'ip', 'mac', 'net',
+    'category', 'country', 'devicePort',
+    'remotePort', 'remoteIpPort', 'remoteNetPort'
+  ].includes(type)) {
+    log.warn('invalid action type: ' + type);
+    return;
   }
 
   if (!target) {

--- a/net2/AppTool.js
+++ b/net2/AppTool.js
@@ -16,14 +16,6 @@
 
 let log = require('./logger.js')(__filename);
 
-let Promise = require('bluebird');
-
-
-let async = require('asyncawait/async');
-let await = require('asyncawait/await');
-
-let util = require('util');
-
 let instance = null;
 class AppTool {
   constructor() {

--- a/net2/HostManager.js
+++ b/net2/HostManager.js
@@ -15,9 +15,6 @@
 'use strict';
 const log = require('./logger.js')(__filename);
 
-var iptool = require('ip');
-var os = require('os');
-var network = require('network');
 var instances = {};
 
 const rclient = require('../util/redis_manager.js').getRedisClient()
@@ -25,7 +22,7 @@ const sclient = require('../util/redis_manager.js').getSubscriptionClient()
 
 const exec = require('child-process-promise').exec
 
-let Promise = require('bluebird');
+const Promise = require('bluebird');
 
 const _ = require('lodash');
 
@@ -35,14 +32,14 @@ const getHitsAsync = Promise.promisify(timeSeries.getHits).bind(timeSeries)
 const platformLoader = require('../platform/PlatformLoader.js');
 const platform = platformLoader.getPlatform();
 
-var Spoofer = require('./Spoofer.js');
+const Spoofer = require('./Spoofer.js');
 var spoofer = null;
-var SysManager = require('./SysManager.js');
-var sysManager = new SysManager('info');
-var DNSManager = require('./DNSManager.js');
-var dnsManager = new DNSManager('error');
-var FlowManager = require('./FlowManager.js');
-var flowManager = new FlowManager('debug');
+const SysManager = require('./SysManager.js');
+const sysManager = new SysManager('info');
+const DNSManager = require('./DNSManager.js');
+const dnsManager = new DNSManager('error');
+const FlowManager = require('./FlowManager.js');
+const flowManager = new FlowManager('debug');
 
 const ShieldManager = require('./ShieldManager.js');
 
@@ -62,43 +59,40 @@ const PolicyManager2 = require('../alarm/PolicyManager2.js');
 const policyManager2 = new PolicyManager2();
 const pm2 = policyManager2
 
-let ExceptionManager = require('../alarm/ExceptionManager.js');
-let exceptionManager = new ExceptionManager();
+const ExceptionManager = require('../alarm/ExceptionManager.js');
+const exceptionManager = new ExceptionManager();
 
-let SpooferManager = require('./SpooferManager.js')
+const SpooferManager = require('./SpooferManager.js')
 
-let modeManager = require('./ModeManager.js');
+const modeManager = require('./ModeManager.js');
 
-let async = require('asyncawait/async');
-let await = require('asyncawait/await');
+const async = require('asyncawait/async');
+const await = require('asyncawait/await');
 
-let f = require('./Firewalla.js');
+const f = require('./Firewalla.js');
 
 const getPreferredBName = require('../util/util.js').getPreferredBName
 
 const license = require('../util/license.js')
 
-var alarmManager = null;
+const bone = require("../lib/Bone.js");
 
-var uuid = require('uuid');
-var bone = require("../lib/Bone.js");
+const util = require('util');
 
-var utils = require('../lib/utils.js');
-
-let fConfig = require('./config.js').getConfig();
+const fConfig = require('./config.js').getConfig();
 
 const fc = require('./config.js')
 
-var _async = require('async');
+const _async = require('async');
 
-var MobileDetect = require('mobile-detect');
+const MobileDetect = require('mobile-detect');
 
-var flowUtil = require('../net2/FlowUtil.js');
+const flowUtil = require('../net2/FlowUtil.js');
 
-let AppTool = require('./AppTool');
-let appTool = new AppTool();
+const AppTool = require('./AppTool');
+const appTool = new AppTool();
 
-var linux = require('../util/linux.js');
+const linux = require('../util/linux.js');
 
 const HostTool = require('../net2/HostTool.js')
 const hostTool = new HostTool()
@@ -370,33 +364,33 @@ class Host {
       });
 
       /*
-          rclient.smembers("host:user_agent:"+this.o.ipv4Addr,(err,results)=> {
-              if (results!=null && results.length>0) {
-                  let bestFamily = null;
-                  let bestOS = null;
-                  for (let i in results) {
-                      let r = JSON.parse(results[i]);
-                      if (r!=null) {
-                          if (r.family.indexOf("Other")==-1) {
-                              bestFamily = r.family;
-                          } else if (r.os.indexOf("Other")==-1) {
-                              bestOS = r.os;
-                          }
-                          break;
-                      }
-                  }
-                  if (bestFamily!=null) {
-                      this.hostname = "(?)"+bestFamily;
-                  } else if (bestOS!=null) {
-                      this.hostname = "(?)"+bestOS;
-                  }
-                  log.info(this.o.name,this.hostname);
-                  if (this.hostname!=null && this.o.name!=this.hostname) {
-                    //this.o.name = this.hostname;
-                      this.save("name",null);
-                  }
+      rclient.smembers("host:user_agent:" + this.o.ipv4Addr, (err, results) => {
+        if (results != null && results.length > 0) {
+          let bestFamily = null;
+          let bestOS = null;
+          for (let i in results) {
+            let r = JSON.parse(results[i]);
+            if (r != null) {
+              if (r.family.indexOf("Other") == -1) {
+                bestFamily = r.family;
+              } else if (r.os.indexOf("Other") == -1) {
+                bestOS = r.os;
               }
-          });
+              break;
+            }
+          }
+          if (bestFamily != null) {
+            this.hostname = "(?)" + bestFamily;
+          } else if (bestOS != null) {
+            this.hostname = "(?)" + bestOS;
+          }
+          log.info(this.o.name, this.hostname);
+          if (this.hostname != null && this.o.name != this.hostname) {
+            //this.o.name = this.hostname;
+            this.save("name", null);
+          }
+        }
+      });
       */
 
     }
@@ -930,33 +924,32 @@ class Host {
   syncToMac(callback) {
     //TODO
     /*
-                if (this.o.mac) {
-                    let mackey = "host:mac:"+this.o.mac.toUpperCase();
-                        rclient.hgetall(key, (err,data)=> {
-                            if ( err == null) {
-                                if (data!=null) {
-                                    data.ipv4 = host.ipv4Addr;
-                                    data.lastActiveTimestamp = Date.now()/1000;
-                                    if (host.macVendor) {
-                                        data.macVendor = host.macVendor;
-                                    }
-                               } else {
-                                   data = {};
-                                   data.ipv4 = host.ipv4Addr;
-                                   data.lastActiveTimestamp = Date.now()/1000;
-                                   data.firstFoundTimestamp = data.lastActiveTimestamp;
-                                   if (host.macVendor) {
-                                        data.macVendor = host.macVendor;
-                                   }
-                               }
-                               rclient.hmset(key,data, (err,result)=> {
-                         });
+    if (this.o.mac) {
+      let mackey = "host:mac:" + this.o.mac.toUpperCase();
+      rclient.hgetall(key, (err, data) => {
+        if (err == null) {
+          if (data != null) {
+            data.ipv4 = host.ipv4Addr;
+            data.lastActiveTimestamp = Date.now() / 1000;
+            if (host.macVendor) {
+              data.macVendor = host.macVendor;
+            }
+          } else {
+            data = {};
+            data.ipv4 = host.ipv4Addr;
+            data.lastActiveTimestamp = Date.now() / 1000;
+            data.firstFoundTimestamp = data.lastActiveTimestamp;
+            if (host.macVendor) {
+              data.macVendor = host.macVendor;
+            }
+          }
+          rclient.hmset(key, data, (err, result) => {
+          });
 
-                }
-                */
+        }
+    */
 
   }
-
 
   listen(tell) {}
 
@@ -1205,6 +1198,10 @@ class Host {
     // deprecated, do nothing
   }
 
+  setPolicyAsync(name, data) {
+    return util.promisify(this.setPolicy).bind(this)(name, data)
+  }
+
   // policy:mac:xxxxx
   setPolicyAsync(name, data) {
     return new Promise((resolve, reject) => {
@@ -1249,49 +1246,6 @@ class Host {
         }
         this.policy.acl = acls;
       }
-    } else if (name === "blockin") { // legacy logic handling, code can be removed in the future
-      if(this.o && this.o.mac) {
-        if(data) {
-          async(() => {
-            // TODO: performance enhancement needed
-            let rule = await (pm2.findPolicy(this.o.mac, "mac"))
-            if(rule) { // already created              
-              callback(null, {blockin: true});
-            } else {
-              // need to create one
-              let rule = new Policy({
-                target: this.o.mac,
-                type: "mac"
-              })
-
-              let resultPolicyRule = await (pm2.checkAndSaveAsync(rule))
-              if(resultPolicyRule) {
-                callback(null, {blockin: true})
-              } else {
-                callback(new Error("failed to apply blockin"))
-              }
-            }
-          })().catch((err) => {
-            callback(err, null)
-          })
-
-        } else {
-          async(() => {
-            // TODO: performance enhancement needed
-            let rule = await (pm2.findPolicy(this.o.mac, "mac"))
-            if(rule) { // already created
-              await (pm2.disableAndDeletePolicy(rule.pid))
-            } 
-
-            callback(null, {blockin: false});
-          })().catch((err) => {
-            callback(err, null)
-          })
-        }
-      }
-
-      return // no need to save policy for blockin case, it's already routed to new policy model
-
     } else {
       if (this.policy[name] != null && this.policy[name] == data) {
         callback(null, null);
@@ -1348,6 +1302,10 @@ class Host {
         callback(err, null);
     });
 
+  }
+
+  loadPolicyAsync() {
+    return util.promisify(this.loadPolicy).bind(this)()
   }
 
   loadPolicy(callback) {
@@ -2569,6 +2527,10 @@ module.exports = class HostManager {
       }
       this.policy.acl = acls;
     }
+  }
+
+  setPolicyAsync(name, data) {
+    return util.promisify(this.setPolicy).bind(this)(name, data)
   }
 
   setPolicy(name, data, callback) {

--- a/net2/main.js
+++ b/net2/main.js
@@ -253,10 +253,6 @@ async function run() {
       return;
     }
 
-    sem.emitEvent({
-      type: 'IPTABLES_READY'
-    });
-
     await mode.reloadSetupMode() // make sure get latest mode from redis
     await ModeManager.apply()
 


### PR DESCRIPTION
- new policy type: remotePort, remoteIpPort, remoteNetPort. 
accepts target of valid entry for ipset type: bitmap:port hash:ip,port hash:net,port
- rework on whitelist, whitelist now work without mangle table and connmark
- device whitelist supported
- remodeled iptables and ipset