### PR TITLE
capture df -h output in hearbeat

### DIFF
--- a/cli/heartbeat.js
+++ b/cli/heartbeat.js
@@ -97,7 +97,8 @@ async function getIPLinks() {
 }
 
 async function getDiskFree() {
-  return await getShellOutput("df -h");
+  const dfFree = await getShellOutput("df -h | jq -sR '[split(\"\n\")[]|select(length>0)|split(\" +\")|add]'");
+  return JSON.parse(dfFree);
 }
 
 async function getEthernetSpeed() {


### PR DESCRIPTION
Sample output

```
  ...
  "diskFree": [
    "Filesystem      Size  Used Avail Use% Mounted on",
    "udev            962M     0  962M   0% /dev",
    "tmpfs           196M   21M  176M  11% /run",
    "/dev/mmcblk0p1  5.2G  2.2G  3.0G  42% /media/root-ro",
    "/dev/mmcblk0p4  6.0G  238M  5.5G   5% /media/root-rw",
    "overlayroot     6.0G  238M  5.5G   5% /",
    "tmpfs           977M     0  977M   0% /dev/shm",
    "tmpfs           5.0M     0  5.0M   0% /run/lock",
    "tmpfs           977M     0  977M   0% /sys/fs/cgroup",
    "/dev/mmcblk0p2  1.9G  7.3M  1.8G   1% /data",
    "/dev/mmcblk0p3  772M   19M  698M   3% /log",
    "tmpfs           196M     0  196M   0% /run/user/1000",
    "tmpfs            30M  156K   30M   1% /bspool"
  ],
 ...
```