### PR TITLE
reduce redis memory info in heartbeat message

### DIFF
--- a/cli/heartbeat.js
+++ b/cli/heartbeat.js
@@ -169,7 +169,7 @@ async function getServiceActiveSince() {
 }
 
 async function getRedisInfoMemory() {
-  const rcimOutput = await getShellOutput("redis-cli info memory");
+  const rcimOutput = await getShellOutput("redis-cli info memory | grep used_memory_ | grep -v _human");
   return rcimOutput.split("\n").reduce( (result, item) => {
     const [item_key, item_value] = item.trim("\r").split(':')
     if ( item_value ) result[item_key] = item_value


### PR DESCRIPTION
After fix , the redisInfoMemory only contains

```
  "redisInfoMemory": {
    "used_memory_rss": "32100352",
    "used_memory_peak": "27774816",
    "used_memory_peak_perc": "98.82%",
    "used_memory_overhead": "3326488",
    "used_memory_startup": "475296",
    "used_memory_dataset": "24121088",
    "used_memory_dataset_perc": "89.43%",
    "used_memory_lua": "60416"
  },
```