### PR TITLE
replace google.com with api.firewalla.com in verification domains to …

### DIFF
--- a/net2/config.json
+++ b/net2/config.json
@@ -74,7 +74,7 @@
     "verificationDomains": [
       "firewalla.encipher.io",
       "github.com",
-      "google.com"
+      "api.firewalla.com"
     ]
   },
   "sysInfo": {


### PR DESCRIPTION
…avoid allowing too many sub domains