### PR TITLE
[trace] refine batch action

### DIFF
--- a/lib/ControllerBot.js
+++ b/lib/ControllerBot.js
@@ -23,7 +23,6 @@ const Trace = require('../util/audit.js');
 const rclient = require('../util/redis_manager.js').getRedisClient()
 const pclient = require('../util/redis_manager.js').getPublishClient();
 const sem = require('../sensor/SensorEventManager.js').getInstance();
-const _ = require('lodash');
 const f = require('../net2/Firewalla.js');
 const Message = require('../net2/Message.js');
 
@@ -188,19 +187,14 @@ module.exports = class {
       try {
         const appInfo = rawmsg.appInfo;
         const mtype = rawmsg.mtype;
-        const data = JSON.parse(JSON.stringify(rawmsg.data)); // clone to prevent it from modifying original data
+        const data = rawmsg.data;
         if (mtype == "init" || mtype == "get") return; // no need record init/get
 
         if (data && data.item === "batchAction") {
-          const actions = data.value;
-          if(_.isArray(actions)) {
-            const filteredActions = actions.filter(action => ["set", "cmd"].includes(action.mtype));
-            if (_.isEmpty(filteredActions)) {
-              return; // no need to record if all actions are get/init
-            } else {
-              data.value = filteredActions; // only keep set & cmd
-            }
-          }
+          // no need to record batch action at all
+          // because each set/cmd action within the batch
+          // will be logged separately
+          return;
         }
 
         const filterItems = ["ping", 'liveStats'];


### PR DESCRIPTION
full diff

```diff
diff --git a/lib/ControllerBot.js b/lib/ControllerBot.js
index 53d2abc02..f1f095e84 100644
--- a/lib/ControllerBot.js
+++ b/lib/ControllerBot.js
@@ -21,7 +21,10 @@
 const log = require('../net2/logger.js')(__filename);
 const Trace = require('../util/audit.js');
 const rclient = require('../util/redis_manager.js').getRedisClient()
+const pclient = require('../util/redis_manager.js').getPublishClient();
 const sem = require('../sensor/SensorEventManager.js').getInstance();
+const f = require('../net2/Firewalla.js');
+const Message = require('../net2/Message.js');

 module.exports = class {
     // config is the controller json file + the controller section of fullConfig
@@ -184,15 +187,24 @@ module.exports = class {
       try {
         const appInfo = rawmsg.appInfo;
         const mtype = rawmsg.mtype;
+        const data = rawmsg.data;
         if (mtype == "init" || mtype == "get") return; // no need record init/get
+
+        if (data && data.item === "batchAction") {
+          // no need to record batch action at all
+          // because each set/cmd action within the batch
+          // will be logged separately
+          return;
+        }
+
         const filterItems = ["ping", 'liveStats'];
-        const item = rawmsg.data && rawmsg.data.item;
+        const item = data && data.item;
         if (!appInfo.eid) return;
         if (filterItems.indexOf(item) != -1) return;
         if (appInfo.platform == "web" && item == "flows") return;
         let tracelog = {
           target: rawmsg.target,
-          action: rawmsg.data,
+          action: data,
           appInfo: {
             deviceName: appInfo.deviceName,
             eid: appInfo.eid,
@@ -206,11 +218,18 @@ module.exports = class {
         if (!tracelog.success) tracelog.error = obj.message
         Trace(tracelog)
         if (['set', 'cmd'].includes(mtype) && rawmsg.id) {
+          const a = Object.assign({ id: rawmsg.id },tracelog);
+
           sem.emitEvent({
             type: "RecordAction",
             message: `Record action ${rawmsg.id}`,
-            action: Object.assign({ id: rawmsg.id },tracelog)
+            action: a
           });
+
+          // publish redis event for debugging
+          if (f.isDevelopmentVersion()) {
+            pclient.publish(Message.MSG_TRACE, JSON.stringify(a));
+          }
         }
       } catch (e) {
         log.error("RecordTracelog error", e, rawmsg, obj);
diff --git a/net2/Message.js b/net2/Message.js
index 71dc4c4a3..a00cbab03 100644
--- a/net2/Message.js
+++ b/net2/Message.js
@@ -61,7 +61,10 @@ const MSG_FLOW_ENRICHED = "FLOW_ENRICHED";
 const MSG_FLOW_ACL_AUDIT_BLOCKED = "FLOW_ACL_AUDIT_BLOCKED";
 const MSG_APP_TIME_USAGE_BUCKET_INCR = "APP_TIME_USAGE_BUCKET_INCR";

+const MSG_TRACE = "sys:trace";
+
 module.exports = {
+  MSG_TRACE,
   MSG_NETWORK_CHANGED,
   MSG_SYS_NETWORK_INFO_UPDATED,
   MSG_SYS_NETWORK_INFO_RELOADED,
```