### PR TITLE
use firerouter API to get listen interfaces of FireAPI in case intern…

### DIFF
--- a/api/bin/www
+++ b/api/bin/www
@@ -48,6 +48,7 @@ const platform = require('../../platform/PlatformLoader').getPlatform()
 
 const http = require('http');
 const i18n = require('i18n');
+const _ = require('lodash');
 
 const PORT = normalizePort(process.env.PORT) || 8833;
 const PORT_LOCAL_API = 8834;
@@ -135,16 +136,21 @@ async function refreshListeningInterfaces(app, local = false) {
   const userInterfaces = await getUserInterfaces()
 
   // local api always use monitoring interfaces
+  // try to get interfaces via firerouter API instead of SysManager in case network info in SysManager of FireAPI is not up-to-date,
+  // e.g., only FireAPI is up and network config is updated with a newly-created wifi lan using wifi dongle
   const listeningInterfaces =
     local && f.isProductionOrBetaOrAlpha() ? [] :
-    !userInterfaces ? sysManager.getMonitoringInterfaces() :
-    userInterfaces.map(intf => sysManager.getInterfaceViaUUID(intf))
+    !userInterfaces ? Object.values(_.pick(await fireRouter.getInterfaceAll(), fireRouter.getMonitoringIntfNames())):
+    userInterfaces.map(intf => {
+      const iface = sysManager.getInterfaceViaUUID(intf);
+      return iface && iface.name && fireRouter.getSingleInterface(iface.name);
+    });
 
   // always listen to localhost
   const targetIP4Set = new Set(
     listeningInterfaces
-      .filter(intf => intf && intf.ip_address)
-      .map(i => i.ip_address)
+      .filter(intf => intf && _.get(intf, ["state", "ip4"]))
+      .map(i => _.get(i, ["state", "ip4"]).split('/')[0])
       .concat('127.0.0.1')
   )
 


### PR DESCRIPTION
…et is unavailable during reboot and firemain is not up