### PR TITLE
update updated timestamp in localMetadata variable to prevent it from…

### DIFF
--- a/extension/cloudcache/cloudcache.js
+++ b/extension/cloudcache/cloudcache.js
@@ -158,6 +158,10 @@ class CloudCacheItem {
       localMetadata.sha256sum && cloudMetadata.sha256sum &&
       localMetadata.sha256sum === cloudMetadata.sha256sum) {
       if (localMetadata.updated < cloudMetadata.updated) {
+        // localMetadata.updated will be checked later to determine if it is expired
+        // in case local metadata file is updated more than 30 days ago and sha256 is still unchanged
+        // need to update this variable to prevent it from being expired
+        localMetadata.updated = cloudMetadata.updated;
         await this.writeLocalMetadata(cloudMetadata);
       }
       if (localIntegrity) {


### PR DESCRIPTION
… being expired if it has not been used in last 30 days