### PR TITLE
stop ovpnclient from flooding syslog

### DIFF
--- a/extension/vpnclient/openvpn_client@.service.template
+++ b/extension/vpnclient/openvpn_client@.service.template
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Restart=always
 RestartSec=3
+LogNamespace=nosyslog
 ExecStart=/home/pi/firewalla/extension/vpnclient/service_start.sh %i
 
 [Install]


### PR DESCRIPTION
everything still goes to /var/log/openvpn_client-CLIENTID.log
https://github.com/firewalla/firewalla/blob/e2cf935406e62c381da251798307d2e167dd47c4/extension/vpnclient/service_start.sh#L9