### PR TITLE
 Add disturbPeriod for Feature "app disturb"

### DIFF
--- a/alarm/AppTimeUsageManager.js
+++ b/alarm/AppTimeUsageManager.js
@@ -35,6 +35,7 @@ const LOCK_RW = "lock_rw";
 const sclient = require('../util/redis_manager.js').getSubscriptionClient();
 const POLICY_STATE_DEFAULT_MODE = 1;
 const POLICY_STATE_DOMAIN_ONLY = 2;
+const DISTURB_INTERVAL = 30;
 
 class AppTimeUsageManager {
   constructor() {
@@ -74,8 +75,11 @@ class AppTimeUsageManager {
 
     setInterval(async () => {
       await this.refreshAppPolicyQuotaUsage();
+    }, 60 * 1000);
+
+    setInterval(async () => {
       await this.refreshAppDistubTimeUsage();
-    }, 30 * 1000);
+    }, DISTURB_INTERVAL * 1000);
   }
 
   async refreshAppPolicyQuotaUsage() {
@@ -136,7 +140,7 @@ class AppTimeUsageManager {
 
         for (const uid of Object.keys(this.acitveDisturbPolicies[pid])) {
           let timeElapse = Math.floor((Date.now() - this.acitveDisturbPolicies[pid][uid]) / 1000);
-          timeElapse = timeElapse < 30 ? timeElapse : 30;
+          timeElapse = timeElapse < DISTURB_INTERVAL ? timeElapse : DISTURB_INTERVAL;
           let disturbTimeUsed = Number(this.registeredPolicies[pid].disturbTimeUsed) + timeElapse;
           try {
             if (disturbTimeUsed >= Number(this.registeredPolicies[pid].disturbMethod.disturbPeriod)) {

--- a/alarm/AppTimeUsageManager.js
+++ b/alarm/AppTimeUsageManager.js
@@ -43,6 +43,7 @@ class AppTimeUsageManager {
     this.registeredPolicies = {};
     this.enforcedPolicies = {};
     this.policyTimeoutTasks = {};
+    this.acitveDisturbPolicies = {};
 
     this._changedAppUIDs = {};
     sem.on(Message.MSG_APP_TIME_USAGE_BUCKET_INCR, (event) => {
@@ -72,63 +73,114 @@ class AppTimeUsageManager {
     });
 
     setInterval(async () => {
-      await lock.acquire(LOCK_RW, async () => {
-        for (const app of Object.keys(this._changedAppUIDs)) {
-          if (!this.watchList[app])
+      await this.refreshAppPolicyQuotaUsage();
+      await this.refreshAppDistubTimeUsage();
+    }, 30 * 1000);
+  }
+
+  async refreshAppPolicyQuotaUsage() {
+    await lock.acquire(LOCK_RW, async () => {
+      for (const app of Object.keys(this._changedAppUIDs)) {
+        if (!this.watchList[app])
+          continue;
+        for (const uid of Object.keys(this._changedAppUIDs[app])) {
+          if (!this.watchList[app][uid])
             continue;
-          for (const uid of Object.keys(this._changedAppUIDs[app])) {
-            if (!this.watchList[app][uid])
-              continue;
-            for (const pid of Object.keys(this.watchList[app][uid])) {
-              const {timeWindows, quota, keys, uniqueMinute} = this.watchList[app][uid][pid];
-              const usage = await this.getTimeUsage(uid, keys, timeWindows, uniqueMinute);
-              this.watchList[app][uid][pid].usage = usage;
-              try {
-                await this.updateAppTimeUsedInPolicy(pid, usage);
-                if (usage >= quota) {
-                  switch (this.enforcedPolicies[pid][uid]) {
-                    case POLICY_STATE_DEFAULT_MODE: {
-                      if (this.policyTimeoutTasks[pid][uid]) {
-                        log.info(`${uid} is still generating ${app} activity after temp default mode rule ${pid} is applied, extend default mode rule duration`);
-                        this.policyTimeoutTasks[pid][uid].refresh();
-                      }
-                      break;
+          for (const pid of Object.keys(this.watchList[app][uid])) {
+            const {timeWindows, quota, keys, uniqueMinute} = this.watchList[app][uid][pid];
+            const usage = await this.getTimeUsage(uid, keys, timeWindows, uniqueMinute);
+            this.watchList[app][uid][pid].usage = usage;
+            try {
+              await this.updateAppTimeUsedInPolicy(pid, usage);
+              if (usage >= quota) {
+                switch (this.enforcedPolicies[pid][uid]) {
+                  case POLICY_STATE_DEFAULT_MODE: {
+                    if (this.policyTimeoutTasks[pid][uid]) {
+                      log.info(`${uid} is still generating ${app} activity after temp default mode rule ${pid} is applied, extend default mode rule duration`);
+                      this.policyTimeoutTasks[pid][uid].refresh();
                     }
-                    case POLICY_STATE_DOMAIN_ONLY: {
-                      log.info(`${uid} is still generating ${app} activity after domain-only mode rule ${pid} is applied, temporarily change to default mode`);
-                      await this.unenforcePolicy(this.registeredPolicies[pid], uid, true);
-                      await this.applyPolicy(pid, uid);
-                      break;
-                    }
-                    default: {
-                      log.info(`${uid} reached ${keys} time usage quota, quota: ${quota}, used: ${usage}, will apply policy ${pid}`);
-                      await this.applyPolicy(pid, uid);
-                    }
+                    break;
+                  }
+                  case POLICY_STATE_DOMAIN_ONLY: {
+                    log.info(`${uid} is still generating ${app} activity after domain-only mode rule ${pid} is applied, temporarily change to default mode`);
+                    await this.unenforcePolicy(this.registeredPolicies[pid], uid, true);
+                    await this.applyPolicy(pid, uid);
+                    break;
+                  }
+                  default: {
+                    log.info(`${uid} reached ${keys} time usage quota, quota: ${quota}, used: ${usage}, will apply policy ${pid}`);
+                    await this.applyPolicy(pid, uid);
                   }
                 }
-              } catch (err) {
-                log.error(`Failed to update app time used in policy ${pid}`, err.message);
               }
+            } catch (err) {
+              log.error(`Failed to update app time used in policy ${pid}`, err.message);
             }
           }
         }
-        this._changedAppUIDs = {};
-      }).catch((err) => {
-        log.error(`Failed to refresh time usage`, err.message);
-      });
-    }, 60 * 1000);
+      }
+      this._changedAppUIDs = {};
+    }).catch((err) => {
+      log.error(`Failed to refresh time usage`, err.message);
+    });
+  }
+
+  async refreshAppDistubTimeUsage() {
+    await lock.acquire(LOCK_RW, async () => {
+      for (const pid of Object.keys(this.acitveDisturbPolicies)) {
+        if (!this.registeredPolicies[pid]) {
+          log.warn(`Cannot find policy with ${pid}, just remove from acitveDisturbPolicies list`);
+          delete this.acitveDisturbPolicies[pid];
+          continue;
+        }
+
+        for (const uid of Object.keys(this.acitveDisturbPolicies[pid])) {
+          let timeElapse = Math.floor((Date.now() - this.acitveDisturbPolicies[pid][uid]) / 1000);
+          timeElapse = timeElapse < 30 ? timeElapse : 30;
+          let disturbTimeUsed = Number(this.registeredPolicies[pid].disturbTimeUsed) + timeElapse;
+          try {
+            if (disturbTimeUsed >= Number(this.registeredPolicies[pid].disturbMethod.disturbPeriod)) {
+              log.info(`Disturb time limit of Policy ${pid} is reached, will change to block mode`);
+              await this.unenforcePolicy(this.registeredPolicies[pid], uid, false);
+              // update policy disturbTimeUsed here to let unenforcePolicy to clear disturb rules.
+              this.registeredPolicies[pid].disturbTimeUsed = disturbTimeUsed;
+              await this.updateDisturbTimeUsedInPolicy(pid, this.registeredPolicies[pid].disturbTimeUsed);
+              await this.applyPolicy(pid, uid);
+              delete this.acitveDisturbPolicies[pid][uid];
+            }else {
+              this.registeredPolicies[pid].disturbTimeUsed = disturbTimeUsed;
+              await this.updateDisturbTimeUsedInPolicy(pid, this.registeredPolicies[pid].disturbTimeUsed);
+            }
+          } catch (err) {
+            log.error(`Failed to update disturb time used in policy ${pid}`, err.message);
+          }
+        }
+      }
+    }).catch((err) => {
+      log.error(`Failed to refresh App disturb time usage`, err.message);
+    });
   }
 
   async applyPolicy(pid, uid) {
-    const policy = this.registeredPolicies[pid];
-    if (!policy) {
+    const p = this.registeredPolicies[pid];
+    if (!p) {
       log.error(`Policy ${pid} not found`);
       return;
     }
+    const policy = Object.assign(Object.create(Policy.prototype), p);
+    const needDisturb = policy.needPolicyDisturb();
     // a default mode policy will be applied first, and will be updated to domain only after a certain timeout
     await this.enforcePolicy(policy, uid, false);
+    if (needDisturb) {
+      this.registeredPolicies[pid].disturbTimeUsed = policy.disturbTimeUsed;
+      log.info(`The policy has been in disturb mode for ${policy.disturbTimeUsed} seconds.`);
+      await this.updateDisturbTimeUsedInPolicy(pid, policy.disturbTimeUsed);
+      this.acitveDisturbPolicies[pid] = {};
+      this.acitveDisturbPolicies[pid][uid] = Date.now();
+    }
+
     this.enforcedPolicies[pid][uid] = POLICY_STATE_DEFAULT_MODE;
-    if (policy.dnsmasq_only) {
+    if (policy.dnsmasq_only && ! needDisturb) {
       this.policyTimeoutTasks[pid][uid] = setTimeout(async () => {
         await lock.acquire(LOCK_RW, async () => {
           if (this.policyTimeoutTasks[pid][uid] && this.enforcedPolicies[pid][uid] === POLICY_STATE_DEFAULT_MODE) {
@@ -231,6 +283,11 @@ class AppTimeUsageManager {
       if (usage >= quota) {
         log.info(`${uid} reached ${keys} time usage quota, quota: ${quota}, used: ${usage}, will apply policy ${pid}`);
         await this.applyPolicy(pid, uid);
+      }else{
+        if (this.registeredPolicies[pid] && this.registeredPolicies[pid].disturbMethod) {
+          this.registeredPolicies[pid].disturbTimeUsed = 0; 
+          await this.updateDisturbTimeUsedInPolicy(pid, this.registeredPolicies[pid].disturbTimeUsed);
+        }
       }
     }
   }
@@ -300,6 +357,9 @@ class AppTimeUsageManager {
       if (this.watchList[key] && this.watchList[key][uid])
         delete this.watchList[key][uid][pid];
     }
+    if (this.acitveDisturbPolicies[pid]) {
+      delete this.acitveDisturbPolicies[pid];
+    }
     if (_.isObject(this.enforcedPolicies[pid])) {
       for (const uid of Object.keys(this.enforcedPolicies[pid]))
         await this.unenforcePolicy(policy, uid, this.enforcedPolicies[pid][uid] === POLICY_STATE_DOMAIN_ONLY);
@@ -355,6 +415,10 @@ class AppTimeUsageManager {
     else if (uid && hostTool.isMacAddress(uid))
       p.scope = [uid];
 
+    if(this.registeredPolicies[p.pid] && this.registeredPolicies[p.pid].disturbTimeUsed) {
+      p.disturbTimeUsed = this.registeredPolicies[p.pid].disturbTimeUsed;
+    }
+
     p.managedBy = "AppTimeUsageManager";
 
     if (p.type === "dns" || p.type === "category")
@@ -368,6 +432,12 @@ class AppTimeUsageManager {
     const PolicyManager2 = require('./PolicyManager2.js');
     const pm2 = new PolicyManager2();
     await pm2.updatePolicyAsync({pid, appTimeUsed: used});
+  }
+
+  async updateDisturbTimeUsedInPolicy(pid, used) {
+    const PolicyManager2 = require('./PolicyManager2.js');
+    const pm2 = new PolicyManager2();
+    await pm2.updatePolicyAsync({pid, disturbTimeUsed: used});
   }
 }
 

--- a/alarm/Policy.js
+++ b/alarm/Policy.js
@@ -648,6 +648,14 @@ class Policy {
     }
   }
 
+  needPolicyDisturb() {
+    if(this.action === "app_block" && this.disturbMethod != null && this.disturbMethod.disturbPeriod != null && Number(this.disturbMethod.disturbPeriod) > 0) {
+      this.disturbTimeUsed = this.disturbTimeUsed || 0;
+      return Number( this.disturbMethod.disturbPeriod) > Number(this.disturbTimeUsed);
+    }
+    return false;
+  }
+
   static getMathcedTarget(policy) {
     let target = "";
     if (policy.scope) {
@@ -672,9 +680,9 @@ class Policy {
 }
 
 Policy.ARRAR_VALUE_KEYS = ["scope", "tag", "guids", "applyRules", "targets"];
-Policy.OBJ_VALUE_KEYS = ["appTimeUsage"];
+Policy.OBJ_VALUE_KEYS = ["appTimeUsage", "disturbMethod"];
 Policy.NUM_VALUE_KEYS = [
-  'seq', 'appTimeUsed', 'priority', 'transferredBytes', 'transferredPackets', 'avgPacketBytes',
+  'seq', 'appTimeUsed', 'priority', 'transferredBytes', 'transferredPackets', 'avgPacketBytes', "disturbTimeUsed"
 ]
 Policy.INTF_PREFIX = "intf:";
 Policy.TAG_PREFIX = "tag:";

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -1328,11 +1328,19 @@ class PolicyManager2 {
     }
 
     // for now, targets is only used for multiple category block/app time limit
-    let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType, guids, parentRgId, targetRgId, ipttl, resolver, flowIsolation, dscpClass, packetDelay, lossRate } = policy;
+    let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType, guids, parentRgId, targetRgId, ipttl, resolver, flowIsolation, dscpClass} = policy;
+    let increaseLatency = null;
+    let dropPacketRate = null;
+    if (policy.disturbMethod) {
+      increaseLatency = policy.disturbMethod.increaseLatency;
+      dropPacketRate = policy.disturbMethod.dropPacketRate;
+      rateLimit = policy.disturbMethod.rateLimit;
+    }
 
     if (action === "app_block")
       action = "block"; // treat app_block same as block, but using a different term for version compatibility, otherwise, block rule will always take effect in previous versions
-    else if (action === "app_disturb")
+    
+    if (policy.needPolicyDisturb())
       action = "qos";  // treat app_disturb same as qos
 
     if (!validActions.includes(action)) {
@@ -1722,7 +1730,7 @@ class PolicyManager2 {
       action, direction, createOrDestroy: "create", ctstate,
       trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
       wanUUID, security, targetRgId, seq, // tlsHostSet, tlsHost,
-      subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+      subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
     }
     if (tlsHostSet || tlsHost || !_.isEmpty(tlsHostSets)) {
       let tlsInstalled = true;
@@ -1774,7 +1782,7 @@ class PolicyManager2 {
 
   async __applyRules(options) {
     if (options.action === "qos" && options.qdisc === "netem") {
-      // for app_disturb action, traffic direction is not specified, we handle both upload and download here.
+      // for app disturb action, traffic direction is not specified, we handle both upload and download here.
       for (const direction of ["upload", "download"]) {
         options.trafficDirection = direction;
         await this._applyRules(options);
@@ -1862,11 +1870,20 @@ class PolicyManager2 {
 
     const type = policy["i.type"] || policy["type"]; //backward compatibility
 
-    let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType, guids, parentRgId, targetRgId, resolver, flowIsolation, dscpClass, packetDelay, lossRate } = policy;
+    let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType, guids, parentRgId, targetRgId, resolver, flowIsolation, dscpClass} = policy;
+
+    let increaseLatency = null;
+    let dropPacketRate = null;
+    if (policy.disturbMethod) {
+      increaseLatency = policy.disturbMethod.increaseLatency;
+      dropPacketRate = policy.disturbMethod.dropPacketRate;
+      rateLimit = policy.disturbMethod.rateLimit;
+    }
 
     if (action === "app_block")
       action = "block";
-    else if (action === "app_disturb")
+    
+    if (policy.needPolicyDisturb())
       action = "qos";  // treat app_disturb same as qos
 
     if (!validActions.includes(action)) {
@@ -2206,7 +2223,7 @@ class PolicyManager2 {
       action, direction, createOrDestroy: "destroy", ctstate,
       trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
       wanUUID, security, targetRgId, seq, // tlsHostSet, tlsHost,
-      subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+      subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
     }
     if (!_.isEmpty(remoteSets)) {
       for (const setPair of remoteSets) {

--- a/control/Block.js
+++ b/control/Block.js
@@ -478,9 +478,9 @@ async function setupGlobalRules(options) {
     action = "block", direction = "bidirection", createOrDestroy = "create", ctstate = null,
     trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
     wanUUID, security, targetRgId, seq = Constants.RULE_SEQ_REG, tlsHostSet, tlsHost,
-    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
   } = options
-  log.verbose(`${createOrDestroy} global rule, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, packetDelay ${packetDelay}, lossRate ${lossRate}`);
+  log.verbose(`${createOrDestroy} global rule, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, increaseLatency ${increaseLatency}, dropPacketRate ${dropPacketRate}`);
   const parameters = [];
   const filterPrio = 1;
   let chainSuffix = "";
@@ -519,7 +519,7 @@ async function setupGlobalRules(options) {
         }
         if (createOrDestroy === "create") {
           await qos.createTCFilter(qosHandler, "1", subclassId, trafficDirection, filterPrio, fwmark);
-          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, packetDelay, lossRate);
+          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, increaseLatency, dropPacketRate);
           await qos.createTCFilter(qosHandler, parentHTBQdisc, qosHandler, trafficDirection, filterPrio, fwmark);
         } else {
           await qos.destroyTCFilter(qosHandler, parentHTBQdisc, trafficDirection, filterPrio, fwmark);
@@ -642,9 +642,9 @@ async function setupGenericIdentitiesRules(options) {
     action = "block", direction = "bidirection", createOrDestroy = "create", ctstate = null,
     trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
     wanUUID, security, targetRgId, seq = Constants.RULE_SEQ_REG, tlsHostSet, tlsHost,
-    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
   } = options
-  log.verbose(`${createOrDestroy} generic identity rule, guids ${JSON.stringify(guids)}, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, packetDelay ${packetDelay}, lossRate ${lossRate}`);
+  log.verbose(`${createOrDestroy} generic identity rule, guids ${JSON.stringify(guids)}, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, increaseLatency ${increaseLatency}, dropPacketRate ${dropPacketRate}`);
   // generic identity has the same priority level as device
   const op = createOrDestroy === "create" ? "-A" : "-D";
   const parameters = [];
@@ -685,7 +685,7 @@ async function setupGenericIdentitiesRules(options) {
         }
         if (createOrDestroy === "create") {
           await qos.createTCFilter(qosHandler, "1", subclassId, trafficDirection, filterPrio, fwmark);
-          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, packetDelay, lossRate);
+          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, increaseLatency, dropPacketRate);
           await qos.createTCFilter(qosHandler, parentHTBQdisc, qosHandler, trafficDirection, filterPrio, fwmark);
         } else {
           await qos.destroyTCFilter(qosHandler, parentHTBQdisc, trafficDirection, filterPrio, fwmark);
@@ -821,9 +821,9 @@ async function setupDevicesRules(options) {
     action = "block", direction = "bidirection", createOrDestroy = "create", ctstate = null,
     trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
     wanUUID, security, targetRgId, seq = Constants.RULE_SEQ_REG, tlsHostSet, tlsHost,
-    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
   } = options
-  log.verbose(`${createOrDestroy} device rule, MAC address ${JSON.stringify(macAddresses)}, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, packetDelay ${packetDelay}, lossRate ${lossRate}`);
+  log.verbose(`${createOrDestroy} device rule, MAC address ${JSON.stringify(macAddresses)}, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, increaseLatency ${increaseLatency}, dropPacketRate ${dropPacketRate}`);
   const op = createOrDestroy === "create" ? "-A" : "-D";
   const parameters = [];
   const filterPrio = 1;
@@ -863,7 +863,7 @@ async function setupDevicesRules(options) {
         }
         if (createOrDestroy === "create") {
           await qos.createTCFilter(qosHandler, "1", subclassId, trafficDirection, filterPrio, fwmark);
-          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, packetDelay, lossRate);
+          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, increaseLatency, dropPacketRate);
           await qos.createTCFilter(qosHandler, parentHTBQdisc, qosHandler, trafficDirection, filterPrio, fwmark);
         } else {
           await qos.destroyTCFilter(qosHandler, parentHTBQdisc, trafficDirection, filterPrio, fwmark);
@@ -990,9 +990,9 @@ async function setupTagsRules(options) {
     action = "block", direction = "bidirection", createOrDestroy = "create", ctstate = null,
     trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
     wanUUID, security, targetRgId, seq = Constants.RULE_SEQ_REG, tlsHostSet, tlsHost,
-    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
   } = options
-  log.verbose(`${createOrDestroy} group rule, policy id ${pid}, group uid ${JSON.stringify(uids)}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, packetDelay ${packetDelay}, lossRate ${lossRate}`);
+  log.verbose(`${createOrDestroy} group rule, policy id ${pid}, group uid ${JSON.stringify(uids)}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, increaseLatency ${increaseLatency}, dropPacketRate ${dropPacketRate}`);
   const op = createOrDestroy === "create" ? "-A" : "-D";
   const parameters = [];
   const filterPrio = 1;
@@ -1037,7 +1037,7 @@ async function setupTagsRules(options) {
           }
           if (createOrDestroy === "create") {
             await qos.createTCFilter(qosHandler, "1", subclassId, trafficDirection, filterPrio, fwmark);
-            await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, packetDelay, lossRate);
+            await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, increaseLatency, dropPacketRate);
             await qos.createTCFilter(qosHandler, parentHTBQdisc, qosHandler, trafficDirection, filterPrio, fwmark);
           } else {
             await qos.destroyTCFilter(qosHandler, parentHTBQdisc, trafficDirection, filterPrio, fwmark);
@@ -1202,9 +1202,9 @@ async function setupIntfsRules(options) {
     action = "block", direction = "bidirection", createOrDestroy = "create", ctstate = null,
     trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
     wanUUID, security, targetRgId, seq = Constants.RULE_SEQ_REG, tlsHostSet, tlsHost,
-    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
   } = options
-  log.verbose(`${createOrDestroy} network rule, policy id ${pid}, uuid ${JSON.stringify(uuids)}, local port ${localPortSet}, remote set ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, packetDelay ${packetDelay}, lossRate ${lossRate}`);
+  log.verbose(`${createOrDestroy} network rule, policy id ${pid}, uuid ${JSON.stringify(uuids)}, local port ${localPortSet}, remote set ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, security ${security}, target rule group UUID ${targetRgId}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, increaseLatency ${increaseLatency}, dropPacketRate ${dropPacketRate}`);
   if (_.isEmpty(uuids))
     return;
   const op = createOrDestroy === "create" ? "-A" : "-D";
@@ -1246,7 +1246,7 @@ async function setupIntfsRules(options) {
         }
         if (createOrDestroy === "create") {
           await qos.createTCFilter(qosHandler, "1", subclassId, trafficDirection, filterPrio, fwmark);
-          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, packetDelay, lossRate);
+          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, increaseLatency, dropPacketRate);
           await qos.createTCFilter(qosHandler, parentHTBQdisc, qosHandler, trafficDirection, filterPrio, fwmark);
         } else {
           await qos.destroyTCFilter(qosHandler, parentHTBQdisc, trafficDirection, filterPrio, fwmark);
@@ -1374,9 +1374,9 @@ async function setupRuleGroupRules(options) {
     action = "block", direction = "bidirection", createOrDestroy = "create", ctstate = null,
     trafficDirection, rateLimit, priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes,
     wanUUID, security, targetRgId, seq = Constants.RULE_SEQ_REG, tlsHostSet, tlsHost,
-    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, packetDelay, lossRate
+    subPrio, routeType, qosHandler, upnp, owanUUID, origDst, origDport, snatIP, flowIsolation, dscpClass, increaseLatency, dropPacketRate
   } = options
-  log.verbose(`${createOrDestroy} global rule, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, parent rule group UUID ${ruleGroupUUID}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, packetDelay ${packetDelay}, lossRate ${lossRate}`);
+  log.verbose(`${createOrDestroy} global rule, policy id ${pid}, local port: ${localPortSet}, remote set4 ${remoteSet4}, remote set6 ${remoteSet6}, remote port ${remotePortSet}, protocol ${proto}, action ${action}, direction ${direction}, ctstate ${ctstate}, traffic direction ${trafficDirection}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}, transferred bytes ${transferredBytes}, transferred packets ${transferredPackets}, average packet bytes ${avgPacketBytes}, wan UUID ${wanUUID}, parent rule group UUID ${ruleGroupUUID}, rule seq ${seq}, tlsHostSet ${tlsHostSet}, tlsHost ${tlsHost}, subPrio ${subPrio}, routeType ${routeType}, qosHandler ${qosHandler}, upnp ${upnp}, owanUUID ${owanUUID}, origDst ${origDst}, origDport ${origDport}, snatIP ${snatIP}, flowIsolation ${flowIsolation}, dscpClass ${dscpClass}, increaseLatency ${increaseLatency}, dropPacketRate ${dropPacketRate}`);
   const op = createOrDestroy === "create" ? "-A" : "-D";
   const filterPrio = 1;
   const parameters = [];
@@ -1417,7 +1417,7 @@ async function setupRuleGroupRules(options) {
         }
         if (createOrDestroy === "create") {
           await qos.createTCFilter(qosHandler, "1", subclassId, trafficDirection, filterPrio, fwmark);
-          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, packetDelay, lossRate);
+          await qos.createQoSClass(qosHandler, parentHTBQdisc, trafficDirection, rateLimit, priority, qdisc, flowIsolation, increaseLatency, dropPacketRate);
           await qos.createTCFilter(qosHandler, parentHTBQdisc, qosHandler, trafficDirection, filterPrio, fwmark);
         } else {
           await qos.destroyTCFilter(qosHandler, parentHTBQdisc, trafficDirection, filterPrio, fwmark);

--- a/control/QoS.js
+++ b/control/QoS.js
@@ -28,8 +28,8 @@ const PRIO_REG = 4;
 const PRIO_LOW = 6;
 const DEFAULT_PRIO = PRIO_REG;
 const DEFAULT_RATE_LIMIT = "10240mbit";
-const DEFAULT_DELAY = "0";
-const DEFAULT_LOSS_RATE = "0";
+const DEFAULT_DELAY = "200";
+const DEFAULT_LOSS_RATE = "40";
 const pl = require('../platform/PlatformLoader.js');
 const platform = pl.getPlatform();
 
@@ -72,7 +72,7 @@ async function deallocateQoSHandlerForPolicy(pid) {
   }
 }
 
-async function createQoSClass(classId, parent, direction, rateLimit, priority, qdisc, isolation, packetDelay, lossRate) {
+async function createQoSClass(classId, parent, direction, rateLimit, priority, qdisc, isolation, increaseLatency, dropPacketRate) {
   if (!platform.isIFBSupported()) {
     log.error("ifb is not supported on this platform");
     return;
@@ -87,8 +87,8 @@ async function createQoSClass(classId, parent, direction, rateLimit, priority, q
   if (!isNaN(rateLimit)) // default unit of rate limit is mbit
     rateLimit = `${rateLimit}mbit`;
 
-  packetDelay = packetDelay || DEFAULT_DELAY;
-  lossRate = lossRate || DEFAULT_LOSS_RATE;
+  increaseLatency = increaseLatency || DEFAULT_DELAY;
+  dropPacketRate = dropPacketRate || DEFAULT_LOSS_RATE;
   priority = priority || DEFAULT_PRIO;
   log.info(`Creating QoS class for classid ${classId}, parent ${parent}, direction ${direction}, rate limit ${rateLimit}, priority ${priority}, qdisc ${qdisc}`);
   if (!classId) {
@@ -112,7 +112,7 @@ async function createQoSClass(classId, parent, direction, rateLimit, priority, q
     }
     case "netem": {
       await exec(`sudo tc class replace dev ${device} parent ${parent}: classid ${parent}:0x${classId} htb prio ${priority} rate ${rateLimit}`).then(() => {
-        return exec(`sudo tc qdisc replace dev ${device} parent ${parent}:0x${classId} ${qdisc} delay ${packetDelay}ms loss ${lossRate}%`);
+        return exec(`sudo tc qdisc replace dev ${device} parent ${parent}:0x${classId} ${qdisc} delay ${increaseLatency}ms loss ${dropPacketRate}%`);
       }).catch((err) => {
         log.error(`Failed to create QoS class ${classId}, direction ${direction}`, err.message);
       });
@@ -160,8 +160,8 @@ async function destroyQoSClass(classId, parent, direction, rateLimit) {
     return;
   }
   if (!rateLimit) {
-    log.info("rateLimit is not defined, no need to destroy tc class");
-    return;
+    log.info("rateLimit is not defined, but is not used in destroyQoSClass");
+    //return;
   }
   const device = direction === 'upload' ? 'ifb0' : 'ifb1';
   classId = Number(classId).toString(16);


### PR DESCRIPTION


 Add disturbPeriod for Feature "app disturb"

1. Solution：

   - A new feature “app_disturb” to slow down the internet without completely blocking it for a user when the time quota is exhausted .

   - some new options and values are added in rule policy, as below:

     ```
     {
         "tag": ["userTag:62"],
         "guids": [],
         "scope": [],
         "type": "category",
         "protocol": "",
         "localPort": "",
         "action": "app_block",
         "cronTime": "0 0 * * *",
         "appTimeUsage": {
           "app": "youtube",
           "quota": 12,
           "period": "0 0 * * *"
         },
         .....
         "qdisc": "netem",            //"netem" is a new value for qdisc type
         "disturbMethod": {           //add new "disturbMethod" object to enable disturb function.
           "disturbPeriod": 180,      //mandatory value for disturb funciont, disturbPeriod > 0 means open disturb function. 
                                      //disturbPeriod is in seconds
           "rateLimit": "200",         //200 as default value, 200 means 200mbits    0.2 means 200kbits
           "dropPacketRate": "30",     // packet loss rate, number between 0~100
           "increaseLatency": "200"    //packet delay time in milliseconds
         },
         "disturbTimeUsed": 0          Used to record the length of time that traffic has been disturbed, in seconds.
       }
     ```

   - Using TC (Traffic Control) netem combined with Iptables to affect the traffic of certain websites or devices through packet loss and latency

   - The new rule may be configured similar with app time limit rule, and need to configure some additional disturb parameters.  

2. Test  Procedure

- 2.1 create a rule policy for youtube according above policy configuration, 

- 2.2 watch video on youtube for a few minutes. 

- 2.3 Video playback should become jerky and blurry  .

- 2.4 check the iptable rules and tc rules for disturb action.   

  ```
      sudo iptables -t mangle -L -v -n --line-numbers|grep you
      sudo tc filter show dev ifb0       #ifb0 for upload   ifb1 for download
      sudo tc filter show dev ifb0 parent 3:
      sudo tc class show dev ifb0
      sudo tc class show dev ifb0 parent 3:
      sudo tc qdisc show dev ifb0
      sudo tc qdisc show dev ifb0 parent 3:c  #0xc is qos handle
  ```

- 2.5 After 180 ~210 seconds (There is a maximum error of 30 seconds, this is because the check period is set to 30 seconds),   the traffic should be blocked now. check the iptable rules and tc rules for disturb action should be removed and new iptable rule for block action should be added.

  ```
     sudo iptables -t filter -L -v -n --line-numbers|grep you
  ```

  

- 2.6 Modify the rule policy to increase the appTimeUsage.quota , then the block iptable rule should be removed and "disturbTimeUsed" will be reset as 0. the traffic will also be recovered.

- 2.7 After the new quota is exhausted,  recheck the traffic status as same as step 2.3 ~ 2.5

- 2.8  To switch the disturb mode to "block" or "time limit block " mode. need to clear disturbMethod and disturbTimeUsed, such as:

  - remove disturbMethod and disturbTimeUsed
  - modify disturbMethod and disturbTimeUsed as below:

  ```
  "disturbMethod": { //FireApi will ignore empty object, so the original disturbMethod can not be replaced by an empty obj.
      "disturbPeriod": 0    
  }
  "disturbTimeUsed": 0
  ```

- 2.9 To switch "block" or "time limit block " mode to "disturb" mode, just add "disturbMethod" and "disturbTimeUsed", such as:

  ```
      "disturbMethod": {           
        "disturbPeriod": 180,      
        "rateLimit": "200",         
        "dropPacketRate": "30",    
        "increaseLatency": "200"    
      },
      "disturbTimeUsed": 0     
  ```

- delete the policy rule.  

- check the related iptable rules and tc rules is cleared.  and can play video on youtube normally







