### PR TITLE
Remove enable option from policy disturbMethod obj.

### DIFF
--- a/alarm/Policy.js
+++ b/alarm/Policy.js
@@ -650,7 +650,7 @@ class Policy {
   }
 
   needPolicyDisturb() {
-    if(this.action === "app_block" && this.disturbMethod != null && this.disturbMethod.enable != null && Number(this.disturbMethod.enable) == 1) {
+    if(this.action === "app_block" && this.disturbMethod != null ) {
       this.disturbMethod.disturbPeriod = this.disturbMethod.disturbPeriod || MAX_APP_DISTURB_PERIOD;
       this.disturbTimeUsed = this.disturbTimeUsed || 0;
       return Number( this.disturbMethod.disturbPeriod) > Number(this.disturbTimeUsed);

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -430,6 +430,9 @@ class PolicyManager2 {
     if (!merged.hasOwnProperty('appTimeUsage') || _.isEmpty(merged.appTimeUsage)) {
       await rclient.hdelAsync(policyKey, "appTimeUsage");
     }
+    if (!merged.hasOwnProperty('disturbMethod') || _.isEmpty(merged.appTimeUsage)) {
+      await rclient.hdelAsync(policyKey, "disturbMethod");
+    }
   }
 
   async savePolicyAsync(policy) {


### PR DESCRIPTION
Remove enable option and use empty  policy disturbMethod obj to disable app disturb feature.