### PR TITLE
Fix Bug of OpenVPN not failback when use tcp proto

### DIFF
--- a/extension/vpnclient/OpenVPNClient.js
+++ b/extension/vpnclient/OpenVPNClient.js
@@ -115,6 +115,9 @@ class OpenVPNClient extends VPNClient {
             if (value.startsWith("tap"))
               this._intfType = "tap";
             break;
+          case "proto":
+            this._proto = options[1];
+            break;
           default:
         }
       }
@@ -437,6 +440,13 @@ class OpenVPNClient extends VPNClient {
     if (_.isArray(result) && result.length == 2)
       endpoints.push({ip: result[0], port: result[1]});
     return endpoints;
+  }
+
+  _forceSwitchWAN() {
+    if (this._proto && this._proto.toLowerCase() === "tcp") {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/net2/FireRouter.js
+++ b/net2/FireRouter.js
@@ -1230,6 +1230,10 @@ class FireRouter {
           if (activeIntfIndex >= 0 && (dualWANStateValue ^ activeBitMask) === (1 << (activeIntfIndex * 2)))
             dualWANStateValue = 0;
         }
+        if (wanSwitched) {
+          const VPNClient = require('../extension/vpnclient/VPNClient.js');
+          VPNClient.notifyWanSwitched();
+        }
       }
       log.debug("labels=", labels);
       era.addStateEvent("dualwan_state", type, dualWANStateValue, labels);


### PR DESCRIPTION
When OpenVPN client use tcp protocol to connect with OpenVPN server.  It always uses the same WAN port as when establishing a TCP connection even if the primary WAN is recovered. So add a vpn reconnect mechanism for tcp type openvpn client when WAN switch happened.