### PR TITLE
fix issue, some celing AP was added into quarantine group

### DIFF
--- a/test/test_NewDeviceTagSensor.js
+++ b/test/test_NewDeviceTagSensor.js
@@ -97,47 +97,47 @@ describe('NewDeviceTagSensor.isFirewallaAP', () => {
     }
   });
 
-  it('should return true for Firewalla AP MAC address "20:6D:31:61"', () => {
+  it('should return true for Firewalla AP MAC address "20:6D:31:61"', async () => {
     const host = {
       o: {
         mac: '20:6D:31:61:CC:CC',
         dhcpName: 'notfirewalla'
       }
     }
-    const result = sensorInstance.isFirewallaAP(host);
+    const result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, true);
   });
 
-  it('should return true for Firewalla Ceiling AP MAC address, perfix "20:6D:31:71" ', () => {
+  it('should return true for Firewalla Ceiling AP MAC address, perfix "20:6D:31:71" ', async () => {
     const host = {
       o: {
         mac: '20:6D:31:71:CC:CC',
         dhcpName: 'notfirewalla'
       }
     }
-    const result = sensorInstance.isFirewallaAP(host);
+    const result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, true);
   });
 
-  it('should return false for non-Firewalla MAC address', () => {
+  it('should return false for non-Firewalla MAC address', async () => {
     const host = {
       o: {
         mac: '00:11:22:33:44:55',
         dhcpName: 'notfirewalla'
       }
     }
-    const result = sensorInstance.isFirewallaAP(host);
+    const result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, false);
   });
 
-  it('should return ture for these APs whose MAC address is start with "20:6D:31" and dhcpName or dhcpLeaseName is FirewallaAP', () => {
+  it('should return ture for these APs whose MAC address is start with "20:6D:31" and dhcpName or dhcpLeaseName is FirewallaAP', async () => {
     let host = {
       o: {
         mac: '20:6D:31:XX:XX:XX',
         dhcpName: 'FirewallaAP'
       }
     }
-    let result = sensorInstance.isFirewallaAP(host);
+    let result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, true);
     host = {
       o: {
@@ -146,19 +146,19 @@ describe('NewDeviceTagSensor.isFirewallaAP', () => {
         "dnsmasq.dhcp.leaseName": "FirewallaAP"
       }
     }
-    result = sensorInstance.isFirewallaAP(host);
+    result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, true);
 
   });
 
- it('should return false for these APs whose MAC address is start with "20:6D:31" and dhcpName or dhcpLeaseName is not FirewallaAP', () => {
+ it('should return false for these APs whose MAC address is start with "20:6D:31" and dhcpName or dhcpLeaseName is not FirewallaAP', async () => {
     let host = {
       o: {
         mac: '20:6D:31:XX:XX:XX',
         dhcpName: 'notFirewallaAP'
       }
     }
-    let result = sensorInstance.isFirewallaAP(host);
+    let result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, false);
     host = {
       o: {
@@ -167,7 +167,7 @@ describe('NewDeviceTagSensor.isFirewallaAP', () => {
         "dnsmasq.dhcp.leaseName": "notFirewallaAP"
       }
     }
-    result = sensorInstance.isFirewallaAP(host);
+    result = await sensorInstance.isFirewallaAP(host);
     assert.equal(result, false);
 
   });


### PR DESCRIPTION
AP might detected by neighbor discovery or other way before discoveried by DHCP, for these device which with Firewalla OUI but dhcpName is not avaliable when doing isFirewallaAP check, wait 10s then check again