### PR TITLE
fix exception in DeviceInfoIntel

### DIFF
--- a/alarm/AlarmManager2.js
+++ b/alarm/AlarmManager2.js
@@ -2190,7 +2190,7 @@ module.exports = class {
       return alarm;
     }
 
-    if (sysManager.isMyIP(deviceIP) || sysManager.isMyIP6(deviceIP)) {
+    if (sysManager.isMyIP(deviceIP, false) || sysManager.isMyIP6(deviceIP, false)) {
       // device is the router itself, do nothing
       return alarm;
     }


### PR DESCRIPTION
use monitoringOnly=false when call isMyIP and isMyIP6 in order to include WAN interface.