### PR TITLE
add check source port in _processIptablesLog

### DIFF
--- a/sensor/ACLAuditLogPlugin.js
+++ b/sensor/ACLAuditLogPlugin.js
@@ -497,6 +497,12 @@ class ACLAuditLogPlugin extends Sensor {
 
     record.mac = mac
 
+    // if record.ac is in ['block', 'route', 'allow', 'disturb'] check record.sp is valid
+    if (['block', 'route', 'allow', 'disturb'].includes(record.ac) && (!record.sp || record.sp.length == 0)) {
+      log.error('Invalid source port info in acl audit log', line);
+      return;
+    }
+
     // try to get host name from conn entries for better timeliness and accuracy
     if (dir === "O" && record.ac === "block") {
       // delay 8 seconds to process outbound block flow, in case ssl/http host is available in zeek's ssl log and will be saved into conn entries


### PR DESCRIPTION
To avoid following exception:
```
[-5] 2025-10-15 22:28:55 [32mINFO[39m BroNotice: Unsupported zeek notice type Signatures::Sensitive_Signature, ignored Signatures::Sensitive_Signature
[-4] 2025-10-15 22:28:57 [31mERROR[39m ACLAuditLogPlugin: Failed to write audit logs TypeError: Cannot read property '0' of undefined
[-3] at RuleStatsPlugin.getPolicyIds (/home/pi/firewalla/sensor/RuleStatsPlugin.js:273:71)
[-2] at RuleStatsPlugin.getMatchedPids (/home/pi/firewalla/sensor/RuleStatsPlugin.js:181:33)
[-1] at ACLAuditLogPlugin.writeLogs (/home/pi/firewalla/sensor/ACLAuditLogPlugin.js:755:62)
>>> [ERROR] [90m    at listOnTimeout 
```
