### PR TITLE
fix bug: openvpn server ipv6 not work on Goldv1

### DIFF
--- a/vpn/server_route_up.sh
+++ b/vpn/server_route_up.sh
@@ -18,6 +18,9 @@ echo "${route_network_1}/${route_netmask_1}" > $SUBNET_FILE
 
 SUBNET6_FILE="/etc/openvpn/ovpn_server/$INSTANCE.subnet6"
 subnetwork6=$(ipcalc -nb $ifconfig_ipv6_local/$ifconfig_ipv6_netbits |awk '$1 == "Prefix:" {print $2}')
+if [ -z "$subnetwork6" ]; then
+  subnetwork6=$(python3 -c "import ipaddress; print(ipaddress.IPv6Network(u'${ifconfig_ipv6_local}/${ifconfig_ipv6_netbits}', strict=False).with_prefixlen)")
+fi
 echo "${subnetwork6}" > $SUBNET6_FILE
 
 LOCAL_FILE="/etc/openvpn/ovpn_server/$INSTANCE.local"


### PR DESCRIPTION
ipcalc version too low, use python script instead