### PR TITLE
ignore terminated flows that has zero orig_bytes but non-zero resp_by…

### DIFF
--- a/net2/BroDetect.js
+++ b/net2/BroDetect.js
@@ -933,7 +933,7 @@ class BroDetect {
           return;
         }
 
-        if (["RSTR", "RSTO", "S1", "S3", "SF"].includes(obj.conn_state) && obj.orig_pkts <= 10 && obj.resp_bytes == 0) {
+        if (["RSTR", "RSTO", "S1", "S3", "SF"].includes(obj.conn_state) && obj.orig_pkts <= 10 && (obj.orig_bytes == 0 || obj.resp_bytes == 0)) {
           log.debug("Conn:Drop:TLS", obj.conn_state, data);
           // Likely blocked by TLS. In normal cases, the first packet is SYN, the second packet is ACK, the third packet is SSL client hello. conn_state will be "RSTR"
           // However, if zeek is listening on bridge interface, it will not capture tcp-reset from iptables due to br_netfilter kernel module.


### PR DESCRIPTION
…tes in zeek conn log