### PR TITLE
fix dnsmasq conf change detection when config files move between directories

### DIFF
--- a/extension/dnsmasq/dnsmasq.js
+++ b/extension/dnsmasq/dnsmasq.js
@@ -2316,7 +2316,7 @@ module.exports = class DNSMASQ {
     try {
       let md5sumNow = '';
       for (const confs of paths) {
-        const stdout = await execAsync(`find ${confs} -type f | (while read FILE; do (cat "\${FILE}"; echo); done;) | sort | md5sum | awk '{print $1}'`).then(r => r.stdout).catch((err) => null);
+        const stdout = await execAsync(`find ${confs} -type f | sort | (while read FILE; do echo "\${FILE}"; cat "\${FILE}"; echo; done;) | md5sum | awk '{print $1}'`).then(r => r.stdout).catch((err) => null);
         md5sumNow = md5sumNow + (stdout ? stdout.split('\n').join('') : '');
       }
       const md5sumBefore = await rclient.getAsync(dnsmasqConfKey);


### PR DESCRIPTION
Include file paths in md5 checksum calculation in checkConfsChange(), so that moving config files between directories is correctly detected as a change and triggers a dnsmasq restart.