### PR TITLE
support multiple targets in app disturb rules

### DIFF
--- a/alarm/PolicyDisturbManager.js
+++ b/alarm/PolicyDisturbManager.js
@@ -91,21 +91,56 @@ class PolicyDisturbManager {
     });
   }
 
+  _getAppNameFromTarget(target) {
+    if (target && target.startsWith('TLX-fw-'))
+      return target.substring('TLX-fw-'.length);
+    return target || "";
+  }
+
+  _getAppNames(policy) {
+    const appNames = [];
+    if (!_.isEmpty(policy.targets)) {
+      for (const t of policy.targets) {
+        const name = this._getAppNameFromTarget(t);
+        if (name && !appNames.includes(name))
+          appNames.push(name);
+      }
+    }
+    const primary = policy.app_name || this._getAppNameFromTarget(policy.target);
+    if (primary && !appNames.includes(primary))
+      appNames.push(primary);
+    return appNames.length > 0 ? appNames : [""];
+  }
+
   async _registerPolicy(policy) {
     const pid = String(policy.pid);
     log.info(`Registering policy ${pid} ...`);
 
-    const appName = policy.app_name || "";
+    const appNames = this._getAppNames(policy);
     const disturbLevel = policy.disturbLevel || "";
     //set default default values
     let defaultDisturbVal = { "rateLimit": 10240, "dropPacketRate": 0, "increaseLatency": 0 };
     let disableQuic = false;
 
-    if (this._appConfValue && this._appConfValue.hasOwnProperty(appName)){
-      disableQuic = this._appConfValue[appName].disableQuic || false;
-      if (this._appConfValue[appName].hasOwnProperty(disturbLevel))
-        defaultDisturbVal = Object.assign(defaultDisturbVal, this._appConfValue[appName][disturbLevel]);
-    } else if (this._generalConfValue && this._generalConfValue.hasOwnProperty(disturbLevel)) {
+    let hasAppConf = false;
+    for (const appName of appNames) {
+      if (this._appConfValue && this._appConfValue.hasOwnProperty(appName)) {
+        hasAppConf = true;
+        // Use the strictest effective behavior when app-specific defaults differ.
+        disableQuic = disableQuic || (this._appConfValue[appName].disableQuic || false);
+        if (this._appConfValue[appName].hasOwnProperty(disturbLevel)) {
+          const appConf = this._appConfValue[appName][disturbLevel];
+          if (appConf.rateLimit != null)
+            defaultDisturbVal.rateLimit = Math.min(defaultDisturbVal.rateLimit, appConf.rateLimit);
+          if (appConf.dropPacketRate != null)
+            defaultDisturbVal.dropPacketRate = Math.max(defaultDisturbVal.dropPacketRate, appConf.dropPacketRate);
+          if (appConf.increaseLatency != null)
+            defaultDisturbVal.increaseLatency = Math.max(defaultDisturbVal.increaseLatency, appConf.increaseLatency);
+        }
+      }
+    }
+
+    if (!hasAppConf && this._generalConfValue && this._generalConfValue.hasOwnProperty(disturbLevel)) {
       defaultDisturbVal = Object.assign(defaultDisturbVal, this._generalConfValue[disturbLevel]);
     }
 

--- a/alarm/PolicyDisturbManager.js
+++ b/alarm/PolicyDisturbManager.js
@@ -18,6 +18,7 @@
 const log = require('../net2/logger.js')(__filename);
 const Policy = require('./Policy.js');
 const _ = require('lodash');
+const crypto = require('crypto');
 const sem = require('../sensor/SensorEventManager.js').getInstance();
 const rclient = require('../util/redis_manager.js').getRedisClient();
 const Message = require('../net2/Message.js');
@@ -25,6 +26,10 @@ const AsyncLock = require('../vendor_lib/async-lock');
 const Constants = require('../net2/Constants.js');
 const lock = new AsyncLock();
 const LOCK_RW = "lock_rw";
+
+function _shortHash(s) {
+  return crypto.createHash('md5').update(String(s)).digest('hex').slice(0, 8);
+}
 
 class PolicyDisturbManager {
 
@@ -48,7 +53,8 @@ class PolicyDisturbManager {
       log.info(`Received ${Message.MSG_APP_DISTURB_VALUE_UPDATED} event, updating app disturb default value`);
       const pids = Object.keys(this.registeredPolicies);
       for (const pid of pids) {
-        const policy = this.registeredPolicies[pid];
+        const state = this.registeredPolicies[pid];
+        const policy = state && state.policy;
         if (!policy) continue;
         try {
           await this.deregisterPolicy(policy);
@@ -91,78 +97,112 @@ class PolicyDisturbManager {
     });
   }
 
+  _getPolicyTargets(policy) {
+    return _.uniq(_.compact(_.concat(policy.targets, policy.target)));
+  }
+
   _getAppNameFromTarget(target) {
     if (target && target.startsWith('TLX-fw-'))
       return target.substring('TLX-fw-'.length);
     return target || "";
   }
 
-  _getAppNames(policy) {
-    const appNames = [];
-    if (!_.isEmpty(policy.targets)) {
-      for (const t of policy.targets) {
-        const name = this._getAppNameFromTarget(t);
-        if (name && !appNames.includes(name))
-          appNames.push(name);
-      }
+  _resolveDisturbParams(target, policy) {
+    const appName = this._getAppNameFromTarget(target) || policy.app_name || "";
+    const disturbLevel = policy.disturbLevel || "";
+    const params = { rateLimit: 10240, dropPacketRate: 0, increaseLatency: 0 };
+    let disableQuic = false;
+
+    if (_.has(this._appConfValue, appName)) {
+      disableQuic = this._appConfValue[appName].disableQuic || false;
+      if (_.has(this._appConfValue[appName], disturbLevel))
+        Object.assign(params, this._appConfValue[appName][disturbLevel]);
+    } else if (_.has(this._generalConfValue, disturbLevel)) {
+      Object.assign(params, this._generalConfValue[disturbLevel]);
     }
-    const primary = policy.app_name || this._getAppNameFromTarget(policy.target);
-    if (primary && !appNames.includes(primary))
-      appNames.push(primary);
-    return appNames;
+
+    if (policy.disturbMethod)
+      Object.assign(params, policy.disturbMethod);
+
+    return { appName, params, disableQuic };
+  }
+
+  // Split one policy (potentially multi-target) into per-target effective policies,
+  // each with its own resolved QoS params and a stable qosSubKey for QoS handler allocation.
+  // Also collect the subset of targets that need QUIC blocking into a single sub-policy,
+  // so block UDP/443 is delivered at parent pid level (avoids mark/ipset collisions).
+  _buildEffectivePolicies(policy) {
+    const pid = String(policy.pid);
+    const targets = this._getPolicyTargets(policy);
+
+    if (_.isEmpty(targets)) {
+      log.warn(`Policy ${pid} has no valid targets for disturb, skip`);
+      return { effectivePolicies: [], quicBlockTargets: [] };
+    }
+
+    const multiTarget = targets.length > 1;
+    const effectivePolicies = [];
+    const quicBlockTargets = [];
+
+    for (const target of targets) {
+      const { appName, params, disableQuic } = this._resolveDisturbParams(target, policy);
+      if (disableQuic) {
+        quicBlockTargets.push(target);
+      }
+
+      const effective = Object.assign(Object.create(Policy.prototype), policy, params, {
+        target,
+        targets: [target],
+        app_name: appName || policy.app_name,
+        disableQuic: false, // handled at parent level via quicBlockTargets
+        qosSubKey: multiTarget ? `disturb_${pid}_${_shortHash(target)}` : undefined,
+      });
+      effectivePolicies.push(effective);
+    }
+
+    return { effectivePolicies, quicBlockTargets };
+  }
+
+  _buildQuicBlockPolicy(policy, quicBlockTargets) {
+    return Object.assign(Object.create(Policy.prototype), policy, {
+      action: "block",
+      protocol: "udp",
+      remotePort: "443",
+      dnsmasq_only: false,
+      target: quicBlockTargets[0],
+      targets: quicBlockTargets.slice(),
+      disableQuic: false,
+      qosSubKey: undefined,
+      disturbPretreatDone: true,
+    });
   }
 
   async _registerPolicy(policy) {
     const pid = String(policy.pid);
-    const appNames = this._getAppNames(policy);
-    log.info(`Registering policy ${pid}, appNames: ${JSON.stringify(appNames)}, disturbLevel: ${policy.disturbLevel || "default"}`);
-    const disturbLevel = policy.disturbLevel || "";
-    //set default default values
-    let defaultDisturbVal = { "rateLimit": 10240, "dropPacketRate": 0, "increaseLatency": 0 };
-    let disableQuic = false;
-
-    let hasAppConf = false;
-    for (const appName of appNames) {
-      if (this._appConfValue && Object.prototype.hasOwnProperty.call(this._appConfValue, appName)) {
-        hasAppConf = true;
-        // Use the strictest effective behavior when app-specific defaults differ.
-        disableQuic = disableQuic || (this._appConfValue[appName].disableQuic || false);
-        if (Object.prototype.hasOwnProperty.call(this._appConfValue[appName], disturbLevel)) {
-          const appConf = this._appConfValue[appName][disturbLevel];
-          if (appConf.rateLimit != null)
-            defaultDisturbVal.rateLimit = Math.min(defaultDisturbVal.rateLimit, appConf.rateLimit);
-          if (appConf.dropPacketRate != null)
-            defaultDisturbVal.dropPacketRate = Math.max(defaultDisturbVal.dropPacketRate, appConf.dropPacketRate);
-          if (appConf.increaseLatency != null)
-            defaultDisturbVal.increaseLatency = Math.max(defaultDisturbVal.increaseLatency, appConf.increaseLatency);
-        }
-      }
-    }
-
-    if (!hasAppConf && this._generalConfValue && Object.prototype.hasOwnProperty.call(this._generalConfValue, disturbLevel)) {
-      defaultDisturbVal = Object.assign(defaultDisturbVal, this._generalConfValue[disturbLevel]);
-    }
-
-    if (policy.disturbMethod) {
-      defaultDisturbVal = Object.assign(defaultDisturbVal, policy.disturbMethod);
-    }
-    policy = Object.assign(policy, defaultDisturbVal);
-    policy.disableQuic = disableQuic;
-    log.info(`Policy ${pid} disturb params: ${JSON.stringify(defaultDisturbVal)}, disableQuic: ${disableQuic}`);
-    this.registeredPolicies[pid] = policy;
+    const { effectivePolicies, quicBlockTargets } = this._buildEffectivePolicies(policy);
+    if (_.isEmpty(effectivePolicies))
+      return;
+    log.info(`Registering policy ${pid} disturbLevel=${policy.disturbLevel || "default"}, targets: ${JSON.stringify(effectivePolicies.map(p => ({ target: p.target, rateLimit: p.rateLimit, dropPacketRate: p.dropPacketRate, increaseLatency: p.increaseLatency })))}, quicBlockTargets=${JSON.stringify(quicBlockTargets)}`);
+    this.registeredPolicies[pid] = { policy: { ...policy }, effectivePolicies, quicBlockTargets };
 
     await this.enforcePolicy(pid);
   }
 
   async enforcePolicy(pid) {
-    if (!this.registeredPolicies[pid])
+    const state = this.registeredPolicies[pid];
+    if (!state)
       return;
-    let p = Object.assign(Object.create(Policy.prototype), this.registeredPolicies[pid]);
-    p.disturbPretreatDone = true;
 
     const PolicyManager2 = require('./PolicyManager2.js');
     const pm2 = new PolicyManager2();
-    await pm2.enforce(p);
+    for (const p of state.effectivePolicies) {
+      p.disturbPretreatDone = true;
+      await pm2.enforce(p);
+    }
+    if (!_.isEmpty(state.quicBlockTargets)) {
+      const quicBlock = this._buildQuicBlockPolicy(state.policy, state.quicBlockTargets);
+      await pm2.enforce(quicBlock);
+    }
   }
 
   async deregisterPolicy(policy) {
@@ -183,14 +223,20 @@ class PolicyDisturbManager {
   }
 
   async unenforcePolicy(pid) {
-    if (!this.registeredPolicies[pid])
+    const state = this.registeredPolicies[pid];
+    if (!state)
       return;
-    let p = Object.assign(Object.create(Policy.prototype), this.registeredPolicies[pid]);
-    p.disturbPretreatDone = true;
 
     const PolicyManager2 = require('./PolicyManager2.js');
     const pm2 = new PolicyManager2();
-    await pm2.unenforce(p);
+    if (!_.isEmpty(state.quicBlockTargets)) {
+      const quicBlock = this._buildQuicBlockPolicy(state.policy, state.quicBlockTargets);
+      await pm2.unenforce(quicBlock);
+    }
+    for (const p of state.effectivePolicies) {
+      p.disturbPretreatDone = true;
+      await pm2.unenforce(p);
+    }
   }
 
 }

--- a/alarm/PolicyDisturbManager.js
+++ b/alarm/PolicyDisturbManager.js
@@ -109,7 +109,7 @@ class PolicyDisturbManager {
     const primary = policy.app_name || this._getAppNameFromTarget(policy.target);
     if (primary && !appNames.includes(primary))
       appNames.push(primary);
-    return appNames.length > 0 ? appNames : [""];
+    return appNames;
   }
 
   async _registerPolicy(policy) {
@@ -123,11 +123,11 @@ class PolicyDisturbManager {
 
     let hasAppConf = false;
     for (const appName of appNames) {
-      if (this._appConfValue && this._appConfValue.hasOwnProperty(appName)) {
+      if (this._appConfValue && Object.prototype.hasOwnProperty.call(this._appConfValue, appName)) {
         hasAppConf = true;
         // Use the strictest effective behavior when app-specific defaults differ.
         disableQuic = disableQuic || (this._appConfValue[appName].disableQuic || false);
-        if (this._appConfValue[appName].hasOwnProperty(disturbLevel)) {
+        if (Object.prototype.hasOwnProperty.call(this._appConfValue[appName], disturbLevel)) {
           const appConf = this._appConfValue[appName][disturbLevel];
           if (appConf.rateLimit != null)
             defaultDisturbVal.rateLimit = Math.min(defaultDisturbVal.rateLimit, appConf.rateLimit);
@@ -139,7 +139,7 @@ class PolicyDisturbManager {
       }
     }
 
-    if (!hasAppConf && this._generalConfValue && this._generalConfValue.hasOwnProperty(disturbLevel)) {
+    if (!hasAppConf && this._generalConfValue && Object.prototype.hasOwnProperty.call(this._generalConfValue, disturbLevel)) {
       defaultDisturbVal = Object.assign(defaultDisturbVal, this._generalConfValue[disturbLevel]);
     }
 

--- a/alarm/PolicyDisturbManager.js
+++ b/alarm/PolicyDisturbManager.js
@@ -114,9 +114,8 @@ class PolicyDisturbManager {
 
   async _registerPolicy(policy) {
     const pid = String(policy.pid);
-    log.info(`Registering policy ${pid} ...`);
-
     const appNames = this._getAppNames(policy);
+    log.info(`Registering policy ${pid}, appNames: ${JSON.stringify(appNames)}, disturbLevel: ${policy.disturbLevel || "default"}`);
     const disturbLevel = policy.disturbLevel || "";
     //set default default values
     let defaultDisturbVal = { "rateLimit": 10240, "dropPacketRate": 0, "increaseLatency": 0 };
@@ -149,6 +148,7 @@ class PolicyDisturbManager {
     }
     policy = Object.assign(policy, defaultDisturbVal);
     policy.disableQuic = disableQuic;
+    log.info(`Policy ${pid} disturb params: ${JSON.stringify(defaultDisturbVal)}, disableQuic: ${disableQuic}`);
     this.registeredPolicies[pid] = policy;
 
     await this.enforcePolicy(pid);

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -1410,6 +1410,7 @@ class PolicyManager2 {
     let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit,
       priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType, guids,
       parentRgId, targetRgId, ipttl, resolver, flowIsolation, dscpClass, increaseLatency, dropPacketRate } = policy;
+    const qosRef = { pid, subKey: policy.qosSubKey };
 
     if (action === "app_block")
       action = "block"; // treat app_block same as block, but using a different term for version compatibility, otherwise, block rule will always take effect in previous versions
@@ -1419,14 +1420,6 @@ class PolicyManager2 {
     if (policy.needPolicyDisturb()) {
       action = "qos";  // treat app_disturb same as qos
       qdisc = "netem";
-      if (policy.disableQuic) {
-        const tmpPolicy = Object.assign(Object.create(Policy.prototype), policy);
-        tmpPolicy.action = "block";
-        tmpPolicy.protocol = "udp";
-        tmpPolicy.remotePort = "443";
-        tmpPolicy.dnsmasq_only = false;
-        await this._enforce(tmpPolicy);
-      }
     }
 
     if (!validActions.includes(action)) {
@@ -1482,7 +1475,7 @@ class PolicyManager2 {
     }
 
     if (action === "qos") {
-      qosHandler = await qos.allocateQoSHanderForPolicy(pid);
+      qosHandler = await qos.allocateQoSHanderForPolicy(qosRef);
     }
 
     const devOpts = { tags, intfs, scope, guids };
@@ -2043,6 +2036,7 @@ class PolicyManager2 {
     let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit,
       priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType,
       guids, parentRgId, targetRgId, resolver, flowIsolation, dscpClass, increaseLatency, dropPacketRate } = policy;
+    const qosRef = { pid, subKey: policy.qosSubKey };
 
     if (action === "app_block")
       action = "block";
@@ -2052,14 +2046,6 @@ class PolicyManager2 {
     if (policy.needPolicyDisturb()) {
       action = "qos";  // treat app_disturb same as qos
       qdisc = "netem";
-      if (policy.disableQuic) {
-        const tmpPolicy = Object.assign(Object.create(Policy.prototype), policy);
-        tmpPolicy.action = "block";
-        tmpPolicy.protocol = "udp";
-        tmpPolicy.remotePort = "443";
-        tmpPolicy.dnsmasq_only = false;
-        await this._unenforce(tmpPolicy);
-      }
     }
 
     if (!validActions.includes(action)) {
@@ -2114,7 +2100,7 @@ class PolicyManager2 {
     }
 
     if (action === "qos")
-      qosHandler = await qos.getQoSHandlerForPolicy(pid);
+      qosHandler = await qos.getQoSHandlerForPolicy(qosRef);
 
     switch (type) {
       case "ip":
@@ -2543,7 +2529,7 @@ class PolicyManager2 {
       }
     }
     if (qosHandler)
-      await qos.deallocateQoSHandlerForPolicy(pid);
+      await qos.deallocateQoSHandlerForPolicy({ pid, subKey: policy.qosSubKey });
   }
 
   async match(alarm) {

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -1406,7 +1406,7 @@ class PolicyManager2 {
       throw new Error("Firewalla and it's cloud service can't be blocked.")
     }
 
-    // for now, targets is only used for multiple category block/app time limit
+    // for now, targets is only used for multiple category block/app time limit/app disturb
     let { pid, scope, target, targets, action = "block", tag, remotePort, localPort, protocol, direction, upnp, trafficDirection, rateLimit,
       priority, qdisc, transferredBytes, transferredPackets, avgPacketBytes, wanUUID, owanUUID, origDst, origDport, snatIP, routeType, guids,
       parentRgId, targetRgId, ipttl, resolver, flowIsolation, dscpClass, increaseLatency, dropPacketRate } = policy;

--- a/control/QoS.js
+++ b/control/QoS.js
@@ -37,12 +37,14 @@ const DEFAULT_LOSS_RATE = "0";
 const pl = require('../platform/PlatformLoader.js');
 const platform = pl.getPlatform();
 
-async function getQoSHandlerForPolicy(pid) {
+function _policyField({ pid, subKey }) {
+  return subKey ? `policy_${pid}_${subKey}` : `policy_${pid}`;
+}
+
+async function getQoSHandlerForPolicy(ref) {
   const policyHandlerMap = (await rclient.hgetallAsync(POLICY_QOS_HANDLER_MAP_KEY)) || {};
-  if (policyHandlerMap[`policy_${pid}`])
-    return policyHandlerMap[`policy_${pid}`];
-  else
-    return null;
+  const field = _policyField(ref);
+  return policyHandlerMap[field] || null;
 }
 
 async function getPolicyForQosHandler(handlerId) {
@@ -53,26 +55,29 @@ async function getPolicyForQosHandler(handlerId) {
     return null;
 }
 
-async function allocateQoSHanderForPolicy(pid) {
+async function allocateQoSHanderForPolicy(ref) {
   const policyHandlerMap = (await rclient.hgetallAsync(POLICY_QOS_HANDLER_MAP_KEY)) || {};
-  if (policyHandlerMap[`policy_${pid}`])
-    return policyHandlerMap[`policy_${pid}`];
-  else {
-    for (let i = 2; i != 127; i++) {
-      if (!policyHandlerMap[`qos_${i}`]) {
-        await rclient.hmsetAsync(POLICY_QOS_HANDLER_MAP_KEY, `policy_${pid}`, i, `qos_${i}`, pid);
-        return i;
-      }
+  const field = _policyField(ref);
+  if (policyHandlerMap[field])
+    return policyHandlerMap[field];
+  for (let i = 2; i != 127; i++) {
+    if (!policyHandlerMap[`qos_${i}`]) {
+      await rclient.hmsetAsync(
+          POLICY_QOS_HANDLER_MAP_KEY,
+          field, i,
+          `qos_${i}`, ref.pid);
+      return i;
     }
-    return null;
   }
+  return null;
 }
 
-async function deallocateQoSHandlerForPolicy(pid) {
-  const qosHandler = await rclient.hgetAsync(POLICY_QOS_HANDLER_MAP_KEY, `policy_${pid}`);
+async function deallocateQoSHandlerForPolicy(ref) {
+  const field = _policyField(ref);
+  const qosHandler = await rclient.hgetAsync(POLICY_QOS_HANDLER_MAP_KEY, field);
   if (qosHandler) {
     await rclient.hdelAsync(POLICY_QOS_HANDLER_MAP_KEY, `qos_${qosHandler}`);
-    await rclient.hdelAsync(POLICY_QOS_HANDLER_MAP_KEY, `policy_${pid}`);
+    await rclient.hdelAsync(POLICY_QOS_HANDLER_MAP_KEY, field);
   }
 }
 


### PR DESCRIPTION
Allow app disturb rules to specify multiple targets, matching the existing multi-target support in block and time-limit rules.