### PR TITLE
Add hidden feature flag to skip device info enrichment for alarm testing

### DIFF
--- a/alarm/AlarmManager2.js
+++ b/alarm/AlarmManager2.js
@@ -93,6 +93,7 @@ const TimeUsageTool = require('../flow/TimeUsageTool.js');
 const sysManager = require('../net2/SysManager.js');
 
 const featureName = 'msp_sync_alarm';
+const featureSkipDeviceInfoEnrich = 'alarm_skip_device_info_enrich';
 
 // TODO: Support suppress alarm for a while
 
@@ -439,7 +440,11 @@ module.exports = class {
         return;
       }
       log.info('alarm:create', alarm);
-      await this.enrichDeviceInfo(alarm);
+      if (!fc.isFeatureOn(featureSkipDeviceInfoEnrich)) {
+        await this.enrichDeviceInfo(alarm);
+      } else {
+        log.info('alarm:create skip device info enrich by feature flag', featureSkipDeviceInfoEnrich);
+      }
       this.enqueueAlarm(alarm); // use enqueue to ensure no dup alarms
     } catch (err) {
       log.warn('cannot create alarm', err.message);

--- a/net2/config.json
+++ b/net2/config.json
@@ -1090,10 +1090,12 @@
     "policy_disturb": true,
     "dap": false,
     "dap_bg_task": true,
-    "record_activity_flow": false
+    "record_activity_flow": false,
+    "alarm_skip_device_info_enrich": false
   },
   "hiddenFeatures": [
-    "naughty_monkey"
+    "naughty_monkey",
+    "alarm_skip_device_info_enrich"
   ],
   "pubKeys": [],
   "firerouter": {


### PR DESCRIPTION
Introduces a hidden feature flag `alarm_skip_device_info_enrich` that bypasses the `enrichDeviceInfo` step during alarm creation