### PR TITLE
restrict bone message control types from app API

### DIFF
--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -3047,6 +3047,9 @@ class netBot extends ControllerBot {
         return
       }
       case "boneMessage": {
+        if (value.control === "script" || value.control === "raw" || value.control === "cloud") {
+          throw { code: 403, msg: `'${value.control}' control is not allowed via app API` };
+        }
         this.boneMsgHandler(value);
         return
       }


### PR DESCRIPTION
## Summary
- Restrict certain bone message control types from the app API path

## Test plan
- [ ] Verify bone message handling works as expected
- [ ] Verify cloud channel is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)