### PR TITLE
fix bug, single job might may cause recycleIpset to be queued

### DIFF
--- a/control/CategoryUpdater.js
+++ b/control/CategoryUpdater.js
@@ -89,7 +89,7 @@ class CategoryUpdater extends CategoryUpdaterBase {
       this.origBfCategoryMap = {};
       this.loadCategoryBfParts();
       this.flowSignatureConfig = {};
-      this.recycleCategoryJob = new scheduler.UpdateJob(this.recycleIPSet.bind(this), 1000);
+      this.recycleCategoryJobs = new Map();
       // key: category, value: map of sigId to map of hashkey string to sig detected server entry
       // {category: {sigId: {hashkey: sigEntry}, ...}, ...}
       this.effectiveCategorySigDtSrvs = new Map();
@@ -164,7 +164,7 @@ class CategoryUpdater extends CategoryUpdaterBase {
                       this.categoryWithPattern.add(event.category);
                   }
                   if (strategy.ipset.enabled) {
-                    await this.recycleCategoryJob.exec(event.category);
+                    await this._getRecycleJob(event.category).exec();
                   }
                 } catch (err) {
                   log.error(`Failed to update category domain ${event.category}`, err.message);
@@ -211,7 +211,7 @@ class CategoryUpdater extends CategoryUpdaterBase {
                     await this.refreshCategoryRecord(event.category);
                     // no need to update dnsmasq because it directly takes effect on hit set update
                     if (strategy.ipset.enabled && strategy.ipset.useHitSet) {
-                      await this.recycleCategoryJob.exec(event.category);
+                      await this._getRecycleJob(event.category).exec();
                     }
                   } catch (err) {
                     log.error(`Failed to update category domain ${event.category} on hit set update`, err.message);
@@ -401,7 +401,7 @@ class CategoryUpdater extends CategoryUpdaterBase {
 
     if (isRecycleRequired) {
       // add the ip of related domains to _dm ipset
-      await this.recycleCategoryJob.exec(category);
+      await this._getRecycleJob(category).exec();
     }
   }
 
@@ -1512,6 +1512,13 @@ class CategoryUpdater extends CategoryUpdaterBase {
 
   isRecycleTaskRunning(category) {
     return this.recycleTasks[category];
+  }
+
+  _getRecycleJob(category) {
+    if (!this.recycleCategoryJobs.has(category)) {
+      this.recycleCategoryJobs.set(category, new scheduler.UpdateJob(() => this.recycleIPSet(category), 1000));
+    }
+    return this.recycleCategoryJobs.get(category);
   }
 
   // rebuild category ipset

--- a/sensor/CategoryUpdateSensor.js
+++ b/sensor/CategoryUpdateSensor.js
@@ -581,6 +581,7 @@ class CategoryUpdateSensor extends Sensor {
           await categoryUpdater.flushRegexDomains(category);
           await dnsmasq.deletePolicyCategoryFilterEntry(category);
           // handle related ipset?
+          categoryUpdater.recycleCategoryJobs.delete(category);
         }
       })
 


### PR DESCRIPTION
A single recycle job may cause the RecycleIpset for multiple categories to be queued.