### PR TITLE
report eMMC wear info in cloud checkin

### DIFF
--- a/extension/sysinfo/SysInfo.js
+++ b/extension/sysinfo/SysInfo.js
@@ -215,7 +215,7 @@ async function getDiskInfo() {
 
 async function getEmmcLife() {
   try {
-    const result = await exec("sudo bash -c 'cat /sys/kernel/debug/mmc*/mmc*:*/ext_csd 2>/dev/null | head -n 1'");
+    const result = await exec("sudo bash -c 'cat /sys/kernel/debug/*mmc*/*mmc*:*/ext_csd 2>/dev/null | head -n 1'");
     const hex = result.stdout.trim();
     if (hex.length < 540) return;
     emmcLife = {

--- a/extension/sysinfo/SysInfo.js
+++ b/extension/sysinfo/SysInfo.js
@@ -91,6 +91,8 @@ let diskUsage = {};
 
 let releaseInfo = {};
 
+let emmcLife = null;
+
 
 getMultiProfileSupportFlag();
 
@@ -122,6 +124,7 @@ async function update() {
       .then(getReleaseInfo)
       .then(getCPUModel)
       .then(getDistributionCodename)
+      .then(getEmmcLife)
   ]);
 
   if(updateFlag) {
@@ -207,6 +210,21 @@ async function getDiskInfo() {
     diskInfo = disks;
   } catch(err) {
     log.error("Failed to get disk info", err);
+  }
+}
+
+async function getEmmcLife() {
+  try {
+    const result = await exec("sudo bash -c 'cat /sys/kernel/debug/mmc*/mmc*:*/ext_csd 2>/dev/null | head -n 1'");
+    const hex = result.stdout.trim();
+    if (hex.length < 540) return;
+    emmcLife = {
+      preEolInfo: parseInt(hex.substr(267 * 2, 2), 16),
+      lifeTimeEstA: parseInt(hex.substr(268 * 2, 2), 16),
+      lifeTimeEstB: parseInt(hex.substr(269 * 2, 2), 16),
+    };
+  } catch (err) {
+    log.debug("Failed to read eMMC ext_csd:", err.message);
   }
 }
 
@@ -461,6 +479,10 @@ async function getSysInfo() {
 
   if(rateLimitInfo) {
     sysinfo.rateLimitInfo = rateLimitInfo;
+  }
+
+  if (emmcLife) {
+    sysinfo.emmcLife = emmcLife;
   }
 
   if (platform.isDockerSupported()) {


### PR DESCRIPTION
## Summary
- Add a periodic reader for the eMMC Extended CSD (`/sys/kernel/debug/mmc*/mmc*:*/ext_csd`) in `extension/sysinfo/SysInfo.js`, capturing the JEDEC wear fields `PRE_EOL_INFO` (byte 267), `DEVICE_LIFE_TIME_EST_TYP_A` (byte 268), and `DEVICE_LIFE_TIME_EST_TYP_B` (byte 269).
- Reuse the existing collector pattern: a module-scoped state var, an async `getEmmcLife()` chained into `update()` (~10 min cadence), and a conditional field on the `getSysInfo()` return object — so the values ride along automatically in `sysInfo.sss.emmcLife` of the Bone checkin payload via `SysManager.getSysInfoAsync()` → `BoneSensor.checkIn()`.
- Silent no-op on platforms without eMMC debugfs (e.g. Gold/Purple/NVMe boxes); `emmcLife` stays `null` and the field is omitted, mirroring the existing `rateLimitInfo` pattern.

## Payload shape (eMMC platforms)
```
sysInfo.sss.emmcLife = { preEolInfo, lifeTimeEstA, lifeTimeEstB }
```
Cloud-side interpretation per JEDEC eMMC 5.x:
- `preEolInfo`: 1 = normal, 2 = warning (≥80% reserved blocks consumed), 3 = urgent (≥90%)
- `lifeTimeEstA` / `lifeTimeEstB`: 1 = 0–10% used, 2 = 10–20%, … 10 = 90–100%, 11 = exceeded

## Test plan
- [ ] On a Red/Blue/Navy box, restart FireMain and confirm `sysInfo.sss.emmcLife` is present in checkin logs with three small integers.
- [ ] On a Gold/Purple box, confirm `emmcLife` is absent from the checkin payload and only a `debug`-level log line (no error) appears.
- [ ] Confirm cadence: `emmcLife` updates on the existing `update()` interval (~10 min), same as the surrounding fields.