### PR TITLE
refine redis save tiers to 60/120/240MB boundaries

### DIFF
--- a/platform/Platform.js
+++ b/platform/Platform.js
@@ -703,17 +703,18 @@ class Platform {
   }
 
   getRedisSaveConfig(rdbSize) {
-    // 900 seconds (15min) for 10 key change
-    // 600 seconds (10min) for 1000 keys change
-    // 5 mins for 100000 keys change
-    if (rdbSize > 209715200) {
-      // rdb size is greater than 200MB
-      return "3600 40 2400 4000 1200 400000";
-    } else if (rdbSize > 52428800) {
-      // rdb size is between 50MB and 200MB
-      return "1800 20 1200 2000 600 200000";
+    if (rdbSize > 251658240) {
+      // > 240MB: primary save every 80 minutes
+      return "14400 80 9600 8000 4800 800000";
+    } else if (rdbSize > 125829120) {
+      // 120-240MB: primary save every 40 minutes
+      return "7200 40 4800 4000 2400 400000";
+    } else if (rdbSize > 62914560) {
+      // 60-120MB: primary save every 20 minutes
+      return "3600 20 2400 2000 1200 200000";
     }
-    return "900 10 600 1000 300 100000";
+    // <= 60MB: primary save every 10 minutes
+    return "1800 10 1200 1000 600 100000";
   }
 }
 

--- a/platform/gse/GSEPlatform.js
+++ b/platform/gse/GSEPlatform.js
@@ -409,14 +409,18 @@ class GSEPlatform extends Platform {
   }
 
   getRedisSaveConfig(rdbSize) {
-    if (rdbSize > 104857600) {
-      // rdb size is greater than 100MB
-      return "7200 40 4800 4000 2400 400000";
-    } else if (rdbSize > 26214400) {
-      // rdb size is between 25MB and 100MB
-      return "3600 20 2400 2000 1200 200000";
+    if (rdbSize > 251658240) {
+      // > 240MB: primary save every 2 hours
+      return "14400 40 9600 4000 7200 400000";
+    } else if (rdbSize > 125829120) {
+      // 120-240MB: primary save every 1 hour
+      return "7200 20 4800 2000 3600 200000";
+    } else if (rdbSize > 62914560) {
+      // 60-120MB: primary save every 30 minutes
+      return "3600 10 2400 1000 1800 100000";
     }
-    return "1800 10 1200 1000 600 100000";
+    // <= 60MB: primary save every 15 minutes
+    return "1800 10 1200 1000 900 100000";
   }
 }
 


### PR DESCRIPTION
## Summary
- Refactor `Platform.getRedisSaveConfig(rdbSize)` into a 4-tier ladder using 60 / 120 / 240 MB boundaries, doubling all three time values per tier vs. the previous 3-tier base. Builds on top of #9200.
- Refactor `GSEPlatform.getRedisSaveConfig(rdbSize)` to the same 4-tier shape but with the last (primary) interval set to 15 / 30 / 60 / 120 min per tier — eMMC platforms snapshot ~2/3 as often as the rest.
- Treat the **last** `<secs>` pair as the primary save interval (worst-case floor under heavy churn); the first two pairs scale up from that.

## Tier ladder

| RDB size | Base `Platform.js` | GSE override | GSE/Base |
|---|---|---|---|
| ≤ 60 MB | `1800 10 1200 1000 600 100000` (10 min) | `1800 10 1200 1000 900 100000` (15 min) | 1.5× |
| 60-120 MB | `3600 20 2400 2000 1200 200000` (20 min) | `3600 10 2400 1000 1800 100000` (30 min) | 1.5× |
| 120-240 MB | `7200 40 4800 4000 2400 400000` (40 min) | `7200 20 4800 2000 3600 200000` (1 h) | 1.5× |
| > 240 MB | `14400 80 9600 8000 4800 800000` (80 min) | `14400 40 9600 4000 7200 400000` (2 h) | 1.5× |

## Rationale
GSE writes to eMMC and was inheriting Gold's NVMe-friendly retention settings (24× DNS-flow retention, 400 MB Redis cap), producing high write amplification per snapshot. Spreading snapshots over longer intervals at larger RDB sizes reduces eMMC wear without giving up durability for small RDBs (which still snapshot at normal cadence).

## Trade-off
On a power-cut with a > 240 MB RDB, the box can now lose up to 80 min (base) or 2 h (GSE) of auto-snapshotted state vs the previous 20 min / 40 min. Explicit BGSAVE calls from policy-change handlers (`_scheduleRedisBackgroundSave` in `controllers/netbot.js` and `sensor/Guardian.js`) are unaffected — user/MSP mutations still trigger a debounced save and survive a power-cut as before.

## Test plan
- [ ] On a Gold (NVMe), restart FireMain; verify `redis-cli config get save` returns the new tier string matching the actual `/data/redis/dump.rdb` size.
- [ ] On a GSE (eMMC), restart FireMain; verify `redis-cli config get save` returns the GSE override string for the current RDB size, not the base string.
- [ ] On a box with RDB just under each boundary, confirm the right tier is selected (e.g., 59 MB → bottom tier, 61 MB → next tier).
- [ ] After a policy change, verify `_scheduleRedisBackgroundSave` still triggers a manual BGSAVE within ~5 s (debouncer) regardless of the new save policy.