### PR TITLE
encipher: generate group AES key from CSPRNG instead of UUIDv4

### DIFF
--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -754,8 +754,10 @@ let legoEptCloud = class {
   }
 
   keygen() {
-    let k = uuid.v4();
-    return k.replace('-', '');
+    // 24 CSPRNG bytes -> exactly 32 base64 chars (192 bits of entropy). The 32-char
+    // ASCII string keeps the wire contract (bkey = utf8(key.substring(0,32))) while
+    // replacing the old uuid.v4() source, which only had ~112-122 bits of real entropy.
+    return crypto.randomBytes(24).toString('base64');
   }
 
   // This is to encrypt message for direct communication between app and pi.


### PR DESCRIPTION
## What

Fix the group AES-256 key generation in `encipher/lib/encipherio.js`: derive the key from a CSPRNG instead of a UUIDv4 string.

Tracking issue: firewalla/firecommit#8590 (Tier 1)

## Problem

`keygen()` returned `uuid.v4().replace('-','')`, and `encrypt`/`decrypt`/`encryptBinary` use `bkey = Buffer.from(key.substring(0,32), "utf8")` as the AES-256 key. That 32-byte key was made of ASCII hex characters (~4 bits each), and:

- a UUIDv4 caps at **122 bits** of entropy, and
- `replace('-','')` was missing the `/g` flag, so 3 dashes remained and `substring(0,32)` kept only ~28 variable hex nibbles (+ the fixed `4` version nibble) ≈ **~112 bits**.

So a nominally 256-bit key had ~112–122 bits of real entropy ("hex != bytes").

## Fix

```js
keygen() {
  return crypto.randomBytes(24).toString('base64'); // exactly 32 chars, 192-bit entropy, all ASCII
}
```

24 CSPRNG bytes → exactly 32 base64 chars → `utf8` still yields 32 key bytes. Real entropy goes from ~112 to **192 bits**, and the dash/`/g` bug is moot.

(`randomBytes(32).toString('hex')` would be 64 chars and `substring(0,32)` would keep 128 bits — same trap. base64 of 24 bytes is the max real entropy through a 32-char printable string.)

## Compatibility / risk

- The key travels as a **string** (RSA-wrapped via `publicEncrypt`; both box and app compute `bkey = utf8(key.substring(0,32))`), so a 32-char base64 string keeps the exact contract.
- **Forward-only, no migration:** `decrypt` is unchanged, so existing stored keys (`sys:ept:me`, `group.key`, `rkey.key`) keep working; only newly generated keys are stronger.
- Verified: new keygen yields a 32-char string → 32-byte `bkey` for every sample.

## Out of scope (Tier 2, tracked in firecommit#8590)

Random per-message IV (vs the current all-zero IV), AES-GCM authentication, and a true raw-bytes 256-bit key — all require lockstep app changes + key versioning, so they are intentionally not in this PR.
