### PR TITLE
encipher: stamp iv=1 in group info on group creation

### DIFF
--- a/net2/FWCloudWrapper.js
+++ b/net2/FWCloudWrapper.js
@@ -51,6 +51,7 @@ async function initializeGroup() {
   let meta = JSON.stringify({
     'type': config.serviceType,
     'member': config.memberType,
+    'iv': 1
   });
   const result = await eptcloud.eptCreateGroup(config.service, meta, config.endpoint_name)
   log.info(result);

--- a/sys/kickstart.js
+++ b/sys/kickstart.js
@@ -191,7 +191,8 @@ async function initializeGroup() {
   let meta = JSON.stringify({
     'type': config.serviceType,
     'member': config.memberType,
-    'model': platform.getName()
+    'model': platform.getName(),
+    'iv': 1
   });
   const result = await eptcloud.eptCreateGroup(config.service, meta, config.endpoint_name)
   log.info(result);


### PR DESCRIPTION
## What

Add an `iv` field (default `1`) to the group `meta` that gets encrypted into `group.info` at group creation, in both `eptCreateGroup` call sites:

- `sys/kickstart.js` (real box pairing) → `{ type, member, model, iv: 1 }`
- `net2/FWCloudWrapper.js` (API/test path) → `{ type, member, iv: 1 }`

## Why

`iv: 1` denotes the legacy fixed all-zero IV scheme currently used by `encrypt`/`decrypt`/`encryptBinary`. Today the encipher IV is a hardcoded constant that is never transmitted, so identical plaintexts produce identical ciphertext. This field stamps a per-group encryption-format marker into new groups so the upcoming per-message random-IV work has a version to negotiate on. Newer groups can set a higher value later.

## Behavior

- No functional change today — `iv: 1` is the format already in use.
- The field lands inside the encrypted `group.info`, readable by members via `decrypt(group.info, group.key)`.
- `encipher/lib/encipherio.js` is unchanged; this is purely additive metadata at the two creation sites.

## Notes

Groundwork for the Tier-2 random-IV / backward-compat effort (per-message IV + capability gating). Follow-up work will read this marker and, once all group members are new enough, negotiate the non-zero-IV format.
