### PR TITLE
netbot: add upgradeIv / downgradeIv cmds for group info iv marker

### DIFF
--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -2288,6 +2288,12 @@ class netBot extends ControllerBot {
       case "rekey":
         await this.eptcloud.reKeyForAll(gid);
         return
+      case "upgradeIv": {
+        // Back-fill the "iv" marker into the group info via the cloud
+        // update-group API. No-op if the group already has iv configured.
+        const ivVersion = (value && value.iv) || 1;
+        return await this.eptcloud.upgradeGroupInfoIV(gid, ivVersion);
+      }
       case "syncLegacyKeyToNewKey":
         await this.eptcloud.syncLegacyKeyToNewKey(gid);
         return

--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -2294,6 +2294,10 @@ class netBot extends ControllerBot {
         const ivVersion = (value && value.iv) || 1;
         return await this.eptcloud.upgradeGroupInfoIV(gid, ivVersion);
       }
+      case "downgradeIv": {
+        // Debugging: remove the "iv" marker from the group info. No-op if unset.
+        return await this.eptcloud.downgradeGroupInfoIV(gid);
+      }
       case "syncLegacyKeyToNewKey":
         await this.eptcloud.syncLegacyKeyToNewKey(gid);
         return

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -367,6 +367,64 @@ let legoEptCloud = class {
     return name
   }
 
+  // Back-fill the "iv" marker into the group's encrypted info via the cloud
+  // update-group API. No-op if the group info already carries an "iv" field.
+  // Returns { updated, iv }.
+  async upgradeGroupInfoIV(gid, ivVersion = 1) {
+    if (this.appId === undefined || gid === undefined) {
+      throw new Error("parameter error");
+    }
+
+    // Fetch the raw group record (pristine name/xname/info); do not go through
+    // groupFind() since parseGroup() rewrites group.name to the decrypted value.
+    const resp = await this.rrWithEptRelogin({
+      uri: `${this.endpoint}/group/${this.appId}/${gid}`,
+      family: 4,
+      method: 'GET',
+      json: true,
+      maxAttempts: 2
+    });
+    const group = resp && resp.body;
+    if (!group || _.isString(group) || !_.isArray(group.symmetricKeys)) {
+      throw new Error("invalid group id " + gid);
+    }
+
+    const sk = group.symmetricKeys.find(s => s.eid == this.eid);
+    if (!sk) {
+      throw new Error("not a member of group " + gid);
+    }
+    // info is encrypted with the base symmetric key (legacy zero IV), not the
+    // rotated rkey, so decrypt/re-encrypt with the base key here.
+    const baseKey = this.privateDecrypt(this.myPrivateKey, sk.key);
+
+    let infoObj = {};
+    if (group.info) {
+      const dec = this.decrypt(group.info, baseKey);
+      infoObj = (dec && this._parseJsonSafe(dec)) || {};
+    }
+
+    if (infoObj.iv != null) {
+      log.info(`upgradeGroupInfoIV: group ${gid} already has iv=${infoObj.iv}, skip`);
+      return { updated: false, iv: infoObj.iv };
+    }
+
+    infoObj.iv = ivVersion;
+    const newInfo = this.encrypt(JSON.stringify(infoObj), baseKey);
+
+    // name and xname are required by the update-group API even when only info
+    // changes; pass the group's current stored values back unchanged.
+    await this.rrWithEptRelogin({
+      uri: `${this.endpoint}/group/${this.appId}/${gid}`,
+      family: 4,
+      method: 'POST',
+      json: { name: group.name, xname: group.xname, info: newInfo },
+      maxAttempts: 3
+    });
+
+    log.info(`upgradeGroupInfoIV: group ${gid} info updated with iv=${ivVersion}`);
+    return { updated: true, iv: ivVersion };
+  }
+
   async eptCreateGroup(name, info, alias) {
     let symmetricKey = this.keygen();
     let group = {};

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -370,13 +370,14 @@ let legoEptCloud = class {
   // Back-fill the "iv" marker into the group's encrypted info via the cloud
   // update-group API. No-op if the group info already carries an "iv" field.
   // Returns { updated, iv }.
-  async upgradeGroupInfoIV(gid, ivVersion = 1) {
+  // Fetch the raw group record plus the decrypted info object for an
+  // info-update. Does not go through groupFind() since parseGroup() rewrites
+  // group.name to the decrypted value. info is encrypted with the base
+  // symmetric key (legacy zero IV), not the rotated rkey.
+  async _getGroupInfoForUpdate(gid) {
     if (this.appId === undefined || gid === undefined) {
       throw new Error("parameter error");
     }
-
-    // Fetch the raw group record (pristine name/xname/info); do not go through
-    // groupFind() since parseGroup() rewrites group.name to the decrypted value.
     const resp = await this.rrWithEptRelogin({
       uri: `${this.endpoint}/group/${this.appId}/${gid}`,
       family: 4,
@@ -388,31 +389,24 @@ let legoEptCloud = class {
     if (!group || _.isString(group) || !_.isArray(group.symmetricKeys)) {
       throw new Error("invalid group id " + gid);
     }
-
     const sk = group.symmetricKeys.find(s => s.eid == this.eid);
     if (!sk) {
       throw new Error("not a member of group " + gid);
     }
-    // info is encrypted with the base symmetric key (legacy zero IV), not the
-    // rotated rkey, so decrypt/re-encrypt with the base key here.
     const baseKey = this.privateDecrypt(this.myPrivateKey, sk.key);
-
     let infoObj = {};
     if (group.info) {
       const dec = this.decrypt(group.info, baseKey);
       infoObj = (dec && this._parseJsonSafe(dec)) || {};
     }
+    return { group, baseKey, infoObj };
+  }
 
-    if (infoObj.iv != null) {
-      log.info(`upgradeGroupInfoIV: group ${gid} already has iv=${infoObj.iv}, skip`);
-      return { updated: false, iv: infoObj.iv };
-    }
-
-    infoObj.iv = ivVersion;
+  // Write an updated info object back via the update-group API. name and xname
+  // are required even when only info changes; pass the current values back
+  // unchanged.
+  async _writeGroupInfo(gid, group, baseKey, infoObj) {
     const newInfo = this.encrypt(JSON.stringify(infoObj), baseKey);
-
-    // name and xname are required by the update-group API even when only info
-    // changes; pass the group's current stored values back unchanged.
     await this.rrWithEptRelogin({
       uri: `${this.endpoint}/group/${this.appId}/${gid}`,
       family: 4,
@@ -420,9 +414,41 @@ let legoEptCloud = class {
       json: { name: group.name, xname: group.xname, info: newInfo },
       maxAttempts: 3
     });
+  }
 
+  // Back-fill the "iv" marker into the group's encrypted info via the cloud
+  // update-group API. No-op if the group info already carries an "iv" field.
+  // Returns { updated, iv }.
+  async upgradeGroupInfoIV(gid, ivVersion = 1) {
+    const { group, baseKey, infoObj } = await this._getGroupInfoForUpdate(gid);
+
+    if (infoObj.iv != null) {
+      log.info(`upgradeGroupInfoIV: group ${gid} already has iv=${infoObj.iv}, skip`);
+      return { updated: false, iv: infoObj.iv };
+    }
+
+    infoObj.iv = ivVersion;
+    await this._writeGroupInfo(gid, group, baseKey, infoObj);
     log.info(`upgradeGroupInfoIV: group ${gid} info updated with iv=${ivVersion}`);
     return { updated: true, iv: ivVersion };
+  }
+
+  // Debugging helper: remove the "iv" marker from the group's encrypted info
+  // via the cloud update-group API. No-op if there is no "iv" field.
+  // Returns { updated, removed }.
+  async downgradeGroupInfoIV(gid) {
+    const { group, baseKey, infoObj } = await this._getGroupInfoForUpdate(gid);
+
+    if (infoObj.iv == null) {
+      log.info(`downgradeGroupInfoIV: group ${gid} has no iv, skip`);
+      return { updated: false, removed: null };
+    }
+
+    const removed = infoObj.iv;
+    delete infoObj.iv;
+    await this._writeGroupInfo(gid, group, baseKey, infoObj);
+    log.info(`downgradeGroupInfoIV: group ${gid} info iv removed (was ${removed})`);
+    return { updated: true, removed };
   }
 
   async eptCreateGroup(name, info, alias) {


### PR DESCRIPTION
## What

Adds a netbot cmd (`item: "upgradeIv"`) that back-fills the `iv` marker into an existing group's encrypted `info`, using the cloud update-group API. No-op if the group already has `iv` configured.

Companion to the group `info.iv` marker (firewalla/firewalla#9297) and the per-request IV work (firecommit#8632 / firewalla/firewalla#9298). New groups get `iv` at creation; this command back-fills groups created before that.

## How

`encipherio.upgradeGroupInfoIV(gid, ivVersion = 1)`:
1. `GET {endpoint}/group/{appId}/{gid}` for the raw group record (not `groupFind()`, which rewrites `group.name` to the decrypted value).
2. Decrypt `group.info` with the **base** group symmetric key (`privateDecrypt` of this eid's `symmetricKeys[].key`) — info rides the base key + legacy zero IV, not the rotated rkey.
3. If `info.iv` is already set → return `{ updated: false, iv }` (no-op).
4. Otherwise set `info.iv = ivVersion`, re-encrypt with the base key, and `POST {endpoint}/group/{appId}/{gid}` with `{ name, xname, info }` — `name`/`xname` are passed back unchanged (both are required by the update-group API).

`netbot.cmdHandler`: `case "upgradeIv"` calls it; `ivVersion` can be overridden via `msg.data.value.iv`, defaulting to `1`.

## Verification (testbed, dev cloud)

Ran the equivalent logic against a real group on box 192.168.201.20 (group info had no `iv`):

```
BEFORE info: {"type":"fb","member":"direct","model":"goldpro"} | iv present: false
POSTing update with name/xname unchanged + new info(iv=1)...
AFTER  info: {"type":"fb","member":"direct","model":"goldpro"} | iv present: false
RESULT: cloud returned 200 but DID NOT persist info
```

The client flow (read → detect missing iv → update with name/xname/info) is correct. Persistence did not take effect because the **dev cloud (dv0) does not have the cloud-side update-group fix deployed** — the documented behavior is "server accepts the request and returns 200 but silently drops the info change." So end-to-end persistence is gated on the cloud fix; the box-side code here is complete and correct.

## Notes / open question

- Default `ivVersion` is `1`. Under the current `info.iv` convention this needs to line up with what enables the per-request random IV on the app side — worth confirming the intended value alongside firecommit#8632.
- Info stays on the base key + zero IV (unchanged storage scheme); only the plaintext gains an `iv` field.

---

**Update:** also added `downgradeIv` (cmd item `downgradeIv`) for debugging — removes the `iv` field from the group info via the same update-group API (no-op if unset). The shared GET-group / decrypt-info / write-info logic is factored into `_getGroupInfoForUpdate()` and `_writeGroupInfo()`, used by both `upgradeGroupInfoIV` and `downgradeGroupInfoIV`.