### PR TITLE
fix adblock strict TLS hostset not refreshing from hit set in real time

### DIFF
--- a/sensor/CategoryExaminerPlugin.js
+++ b/sensor/CategoryExaminerPlugin.js
@@ -404,6 +404,8 @@ class CategoryExaminerPlugin extends Sensor {
 
         await this.limitHitSet(category, MAX_CONFIRM_SET_SIZE);
         await this.limitPassthroughSet(category, MAX_CONFIRM_SET_SIZE);
+
+        this.sendUpdateNotification(category);
       }
     }
   }


### PR DESCRIPTION
### Problem
In adblock strict mode, newly learned ad domains were not populated to tls hostset.

### Root cause
The learning pipeline (dnsmasq bloom match → bf_server_match → examiner → cloud confirm → hit set) worked and the Redis hit set grew correctly.
But `confirmJob`'s inline branch (adblock_strict / bf-mapped categories) never called `sendUpdateNotification`, so `UPDATE_CATEGORY_HITSET` was never emitted and `refreshTLSCategory` never rebuilt the /proc hostset.
The `_confirmCloudCategoryDomains` path (oisd-style) already had it; the inline path did not. Only the daily 3am cron bridged hit set → hostset.

### Fix
Emit `sendUpdateNotification(category)` at the end of the inline confirm branch, so the TLS hostset refreshes within seconds of a hit-set update.