### PR TITLE
encipher: AES-256-GCM authenticated encryption (stacked on #9298)

### DIFF
--- a/api/lib/Encryption.js
+++ b/api/lib/Encryption.js
@@ -21,7 +21,6 @@ let instance = null;
 const log = require("../../net2/logger.js")(__filename);
 
 const _ = require('lodash')
-const crypto = require('crypto')
 
 module.exports = class {
   constructor() {
@@ -59,8 +58,8 @@ module.exports = class {
 
     // decryptRequest parses the { iv, message } envelope once and returns usedIv;
     // a request that carried an iv gets its reply mirrored with a fresh iv.
-    cloudWrapper.getCloud().decryptRequest(gid, message).then(({ decrypted: decryptedMessage, usedIv }) => {
-      req.reqUsedIV = usedIv;
+    cloudWrapper.getCloud().decryptRequest(gid, message).then(({ decrypted: decryptedMessage, scheme }) => {
+      req.reqScheme = scheme;
       decryptedMessage.mtype = decryptedMessage.message.mtype;
       req.body = decryptedMessage;
       req.id = _.get(decryptedMessage, [ 'message', 'obj', 'id' ], undefined)
@@ -89,23 +88,21 @@ module.exports = class {
       return;
     }
 
-    // Only use a random IV in the reply when the client negotiated one on the
-    // request (req.reqUsedIV) and this is not a streaming response. Streaming
-    // stays on the legacy zero IV for now (its SSE frame carries no IV field).
-    const useIV = req.reqUsedIV && !streaming;
-    const ivBuf = useIV ? crypto.randomBytes(16) : null;
+    // Mirror the request scheme (gcm / cbc-iv / legacy) on the reply. Streaming
+    // stays on the legacy zero IV for now (its SSE frame carries no envelope).
+    const scheme = streaming ? 'legacy' : (req.reqScheme || 'legacy');
 
     // log.info('Response Data:', JSON.parse(body));
     const time = process.hrtime();
-    cloudWrapper.getCloud().encryptResponse(gid, body, ivBuf).then((encryptedResponse) => {
+    cloudWrapper.getCloud().encryptResponse(gid, body, scheme).then((encryptedResponse) => {
       log.debug(`${req.id} Encrypt Cost Time: ${process.hrtime(time)[1]/1e6} ms`);
 
       if(streaming){
         res.body = encryptedResponse;
         next();
       } else {
-        // encryptedResponse is the { iv, message } envelope when useIV, else
-        // legacy bare base64; the iv travels inside message, not a top-level field.
+        // encryptedResponse is the scheme envelope (gcm/cbc-iv) or legacy bare
+        // base64; iv/tag travel inside message, not as top-level fields.
         res.json({ message: encryptedResponse });
       }
     }).catch((err) => {

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -763,11 +763,51 @@ let legoEptCloud = class {
     }
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       if (parsed.message != null) {
-        return { iv: parsed.iv != null ? parsed.iv : null, ct: parsed.message };
+        return {
+          alg: parsed.alg,                              // "gcm" or undefined (CBC)
+          iv: parsed.iv != null ? parsed.iv : null,     // CBC IV or GCM nonce (base64)
+          ct: parsed.message,
+          tag: parsed.tag != null ? parsed.tag : null   // GCM auth tag (base64)
+        };
       }
       return { invalid: true }; // object without a message field
     }
     return { iv: null, ct: text }; // number/boolean/array/null -> treat as legacy base64
+  }
+
+  // The scheme a parsed envelope represents: 'gcm' | 'cbc-iv' | 'legacy'.
+  _schemeOf(env) {
+    if (env.alg === 'gcm') return 'gcm';
+    if (env.iv != null) return 'cbc-iv';
+    return 'legacy';
+  }
+
+  // Normalize a GCM nonce to a 12-byte Buffer (canonical base64 = 16 chars).
+  _normalizeNonce(nonce) {
+    if (Buffer.isBuffer(nonce)) {
+      if (nonce.length !== 12) throw new Error(`Invalid GCM nonce length ${nonce.length}, expected 12 bytes`);
+      return nonce;
+    }
+    if (typeof nonce !== 'string' || !/^[A-Za-z0-9+/]{16}$/.test(nonce)) {
+      throw new Error('Invalid GCM nonce: expected base64 of 12 bytes');
+    }
+    const b = Buffer.from(nonce, 'base64');
+    if (b.length !== 12 || b.toString('base64') !== nonce) {
+      throw new Error('Invalid GCM nonce: expected base64 of 12 bytes');
+    }
+    return b;
+  }
+
+  // Normalize a GCM auth tag to a 16-byte Buffer (canonical base64 = "...==").
+  _normalizeTag(tag) {
+    if (typeof tag !== 'string' || !/^[A-Za-z0-9+/]{22}==$/.test(tag)) {
+      throw new Error('Invalid GCM tag: expected base64 of 16 bytes');
+    }
+    const b = Buffer.from(tag, 'base64');
+    if (b.length !== 16 || b.toString('base64') !== tag) {
+      throw new Error('Invalid GCM tag: expected base64 of 16 bytes');
+    }
+    return b;
   }
 
   // Encrypt utf8 text. When iv is provided, returns a JSON envelope string
@@ -804,24 +844,48 @@ let legoEptCloud = class {
 
   // Decrypt a parsed envelope { iv, ct }. Throws on bad IV/padding; callers that
   // want null-on-error (decrypt) wrap this in try/catch.
-  _decryptWithEnvelope(env, key) {
+  _decryptWithEnvelope(env, key, gid) {
     const bkey = Buffer.from(key.substring(0, 32), "utf8");
+    if (env.alg === 'gcm') {
+      // GCM: authenticated. Requires gid for AAD; final() throws on tag mismatch.
+      if (gid == null) throw new Error('gcm decrypt requires gid for AAD');
+      const decipher = crypto.createDecipheriv('aes-256-gcm', bkey, this._normalizeNonce(env.iv));
+      decipher.setAAD(Buffer.from(gid, 'utf8'));
+      decipher.setAuthTag(this._normalizeTag(env.tag));
+      let dec = decipher.update(env.ct, 'base64', 'utf8');
+      dec += decipher.final('utf8');
+      return dec;
+    }
     const decipher = crypto.createDecipheriv(this.cryptoalgorithem, bkey, this._normalizeIV(env.iv));
     let dec = decipher.update(env.ct, 'base64', 'utf8');
     dec += decipher.final('utf8');
     return dec;
   }
 
+  // Encrypt with AES-256-GCM into a { alg:"gcm", iv, message, tag } envelope.
+  // A fresh 12-byte nonce is generated per call; gid is bound as AAD.
+  _encryptGcm(text, key, gid) {
+    if (gid == null) throw new Error('gcm encrypt requires gid for AAD');
+    const bkey = Buffer.from(key.substring(0, 32), "utf8");
+    const nonce = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', bkey, nonce);
+    cipher.setAAD(Buffer.from(gid, 'utf8'));
+    let ct = cipher.update(text, 'utf8', 'base64');
+    ct += cipher.final('base64');
+    const tag = cipher.getAuthTag();
+    return JSON.stringify({ alg: 'gcm', iv: nonce.toString('base64'), message: ct, tag: tag.toString('base64') });
+  }
+
   // Decrypt a message value. The IV (if any) is carried inside the value via
   // the { iv, message } envelope; see _parseEnvelope for the accepted forms.
-  decrypt(text, key) {
+  decrypt(text, key, gid) {
     try {
       const env = this._parseEnvelope(text);
       if (env.invalid) {
         log.error("Failed to decrypt message: invalid envelope (no message field)");
         return null;
       }
-      return this._decryptWithEnvelope(env, key);
+      return this._decryptWithEnvelope(env, key, gid);
     } catch(err) {
       log.error("Failed to decrypt message, err:", err);
       return null;
@@ -845,7 +909,7 @@ let legoEptCloud = class {
         }
         let decrypted;
         try {
-          decrypted = this._decryptWithEnvelope(env, key);
+          decrypted = this._decryptWithEnvelope(env, key, gid);
         } catch (e) {
           log.error("Failed to decrypt message, err:", e);
           reject(new Error("decrypt_error"));
@@ -853,7 +917,7 @@ let legoEptCloud = class {
         }
         const msgJson = this._parseJsonSafe(decrypted);
         if (msgJson != null)
-          resolve({ decrypted: msgJson, usedIv: env.iv != null });
+          resolve({ decrypted: msgJson, scheme: this._schemeOf(env) });
         else
           reject(new Error("Malformed JSON"));
       });
@@ -863,7 +927,11 @@ let legoEptCloud = class {
   // IV-aware response encryption for the netbot req/response path. Encrypts body
   // with the given IV (Buffer or base64) and returns a promise of the base64
   // ciphertext. When iv is absent, the legacy zero IV is used.
-  encryptResponse(gid, body, iv) {
+  // Encrypt a reply in the given scheme so it mirrors the request:
+  //   'gcm'     -> { alg:"gcm", iv, message, tag } (AAD=gid)
+  //   'cbc-iv'  -> { iv, message } with a fresh random IV
+  //   'legacy'  -> bare base64 (zero IV)
+  encryptResponse(gid, body, scheme) {
     return new Promise((resolve, reject) => {
       this.getKey(gid, false, (err, key) => {
         if (key == null) {
@@ -871,7 +939,12 @@ let legoEptCloud = class {
           return;
         }
         try {
-          resolve(this.encrypt(body, key, iv));
+          if (scheme === 'gcm')
+            resolve(this._encryptGcm(body, key, gid));
+          else if (scheme === 'cbc-iv')
+            resolve(this.encrypt(body, key, crypto.randomBytes(16)));
+          else
+            resolve(this.encrypt(body, key)); // legacy zero IV
         } catch (e) {
           reject(e);
         }

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -94,6 +94,9 @@ let legoEptCloud = class {
       }
       this.token = null;
       rclient.hgetAsync('sys:ept:me', 'eid').then(eid => this.eid = eid)
+      // cache the box's own group id locally; used as the GCM AAD so it doesn't
+      // depend on the (client-supplied) gid in the request URL.
+      rclient.hgetAsync('sys:ept', 'gid').then(gid => this.gid = gid).catch(() => {})
       this.groupCache = {};
       this.cryptoalgorithem = 'aes-256-cbc';
       this.name = name;
@@ -855,13 +858,20 @@ let legoEptCloud = class {
 
   // Decrypt a parsed envelope { iv, ct }. Throws on bad IV/padding; callers that
   // want null-on-error (decrypt) wrap this in try/catch.
-  _decryptWithEnvelope(env, key, gid) {
+  // The box's own group id (loaded locally, not from the request). Used as the
+  // GCM AAD so authentication binds to the box's group, independent of the
+  // client-supplied URL gid.
+  _localGid() {
+    if (!this.gid) throw new Error('local gid not available for GCM AAD');
+    return Buffer.from(this.gid, 'utf8');
+  }
+
+  _decryptWithEnvelope(env, key) {
     const bkey = Buffer.from(key.substring(0, 32), "utf8");
     if (env.alg === 'gcm') {
-      // GCM: authenticated. Requires gid for AAD; final() throws on tag mismatch.
-      if (gid == null) throw new Error('gcm decrypt requires gid for AAD');
+      // GCM: authenticated. AAD = the box's local gid; final() throws on mismatch.
       const decipher = crypto.createDecipheriv('aes-256-gcm', bkey, this._normalizeNonce(env.iv));
-      decipher.setAAD(Buffer.from(gid, 'utf8'));
+      decipher.setAAD(this._localGid());
       decipher.setAuthTag(this._normalizeTag(env.tag));
       let dec = decipher.update(env.ct, 'base64', 'utf8');
       dec += decipher.final('utf8');
@@ -874,13 +884,12 @@ let legoEptCloud = class {
   }
 
   // Encrypt with AES-256-GCM into a { alg:"gcm", iv, message, tag } envelope.
-  // A fresh 12-byte nonce is generated per call; gid is bound as AAD.
-  _encryptGcm(text, key, gid) {
-    if (gid == null) throw new Error('gcm encrypt requires gid for AAD');
+  // A fresh 12-byte nonce is generated per call; the box's local gid is AAD.
+  _encryptGcm(text, key) {
     const bkey = Buffer.from(key.substring(0, 32), "utf8");
     const nonce = crypto.randomBytes(12);
     const cipher = crypto.createCipheriv('aes-256-gcm', bkey, nonce);
-    cipher.setAAD(Buffer.from(gid, 'utf8'));
+    cipher.setAAD(this._localGid());
     let ct = cipher.update(text, 'utf8', 'base64');
     ct += cipher.final('base64');
     const tag = cipher.getAuthTag();
@@ -889,14 +898,14 @@ let legoEptCloud = class {
 
   // Decrypt a message value. The IV (if any) is carried inside the value via
   // the { iv, message } envelope; see _parseEnvelope for the accepted forms.
-  decrypt(text, key, gid) {
+  decrypt(text, key) {
     try {
       const env = this._parseEnvelope(text);
       if (env.invalid) {
         log.error("Failed to decrypt message: invalid envelope (no message field)");
         return null;
       }
-      return this._decryptWithEnvelope(env, key, gid);
+      return this._decryptWithEnvelope(env, key);
     } catch(err) {
       log.error("Failed to decrypt message, err:", err);
       return null;
@@ -920,7 +929,7 @@ let legoEptCloud = class {
         }
         let decrypted;
         try {
-          decrypted = this._decryptWithEnvelope(env, key, gid);
+          decrypted = this._decryptWithEnvelope(env, key);
         } catch (e) {
           log.error("Failed to decrypt message, err:", e);
           reject(new Error("decrypt_error"));
@@ -951,7 +960,7 @@ let legoEptCloud = class {
         }
         try {
           if (scheme === 'gcm')
-            resolve(this._encryptGcm(body, key, gid));
+            resolve(this._encryptGcm(body, key));
           else if (scheme === 'cbc-iv')
             resolve(this.encrypt(body, key, crypto.randomBytes(16)));
           else

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -753,10 +753,21 @@ let legoEptCloud = class {
   // envelope extensible (e.g. a future auth tag can be added as another field).
   _parseEnvelope(text) {
     let parsed;
-    try {
-      parsed = JSON.parse(text);
-    } catch (e) {
-      return { iv: null, ct: text }; // not JSON -> raw base64 (legacy)
+    if (text !== null && typeof text === 'object' && !Buffer.isBuffer(text)) {
+      // Already-parsed envelope object (a client that put `message` as a nested
+      // JSON object rather than a JSON string). Accept it directly.
+      parsed = text;
+    } else if (typeof text === 'string' && (text[0] === '{' || text[0] === '"')) {
+      // Only the JSON envelope forms start with '{' or '"'. A legacy bare-base64
+      // string never does (base64 alphabet), so skip JSON.parse and its
+      // exception entirely for the common legacy case.
+      try {
+        parsed = JSON.parse(text);
+      } catch (e) {
+        return { iv: null, ct: text }; // malformed JSON -> treat as legacy base64
+      }
+    } else {
+      return { iv: null, ct: text }; // bare base64 (legacy) or non-string
     }
     if (typeof parsed === 'string') {
       return { iv: null, ct: parsed }; // JSON-encoded string (legacy)

--- a/scripts/test_encipher_iv.js
+++ b/scripts/test_encipher_iv.js
@@ -24,11 +24,12 @@
  *
  * Usage (run on the box):
  *   node scripts/test_encipher_iv.js              # legacy zero IV (bare base64)
- *   node scripts/test_encipher_iv.js --iv         # random IV (embedded in { iv, message } envelope)
+ *   node scripts/test_encipher_iv.js --iv         # random-IV CBC ({ iv, message } envelope)
+ *   node scripts/test_encipher_iv.js --gcm        # AES-256-GCM ({ alg, iv, message, tag }, AAD=gid)
  *   node scripts/test_encipher_iv.js --gid <gid>  # override group id
  *
- * --iv against a box that does not support the envelope yields HTTP 400/412
- * (it decrypts the envelope with the zero IV and gets garbage).
+ * The box mirrors the request scheme on its reply. --iv/--gcm against a box that
+ * does not support them yields HTTP 400/412.
  */
 
 const path = require('path');
@@ -44,35 +45,54 @@ const ALGO = 'aes-256-cbc';
 const ZERO = Buffer.alloc(16);
 const PORT = 8833;
 
-// --iv sends the random-IV envelope; default is the legacy zero IV.
+// Scheme: --gcm (authenticated), --iv (random-IV CBC), else legacy zero IV.
+const useGCM = process.argv.includes('--gcm');
 const useIV = process.argv.includes('--iv');
 const gidArgIdx = process.argv.indexOf('--gid');
 const gidArg = gidArgIdx >= 0 ? process.argv[gidArgIdx + 1] : null;
 
-// Encrypt to the wire format: { iv, message } JSON envelope when ivBuf is given,
-// else legacy bare base64 (zero IV). Mirrors encipher encrypt().
-function enc(text, key, ivBuf) {
+// Encrypt to the wire format. scheme: 'gcm' | 'cbc-iv' | 'legacy'. Mirrors encipher.
+function enc(text, key, scheme, gid) {
   const bkey = Buffer.from(key.substring(0, 32), 'utf8');
-  const iv = ivBuf || ZERO;
-  const c = crypto.createCipheriv(ALGO, bkey, iv);
-  const ct = c.update(text, 'utf8', 'base64') + c.final('base64');
-  return ivBuf ? JSON.stringify({ iv: ivBuf.toString('base64'), message: ct }) : ct;
+  if (scheme === 'gcm') {
+    const nonce = crypto.randomBytes(12);
+    const c = crypto.createCipheriv('aes-256-gcm', bkey, nonce);
+    c.setAAD(Buffer.from(gid, 'utf8'));
+    const ct = c.update(text, 'utf8', 'base64') + c.final('base64');
+    return JSON.stringify({ alg: 'gcm', iv: nonce.toString('base64'), message: ct, tag: c.getAuthTag().toString('base64') });
+  }
+  if (scheme === 'cbc-iv') {
+    const iv = crypto.randomBytes(16);
+    const c = crypto.createCipheriv(ALGO, bkey, iv);
+    const ct = c.update(text, 'utf8', 'base64') + c.final('base64');
+    return JSON.stringify({ iv: iv.toString('base64'), message: ct });
+  }
+  const c = crypto.createCipheriv(ALGO, bkey, ZERO);
+  return c.update(text, 'utf8', 'base64') + c.final('base64');
 }
-// Decrypt a wire value; the IV (if any) is embedded in the { iv, message }
-// envelope. Returns { plaintext, usedIv }. Mirrors encipher _parseEnvelope + decrypt.
-function decEnvelope(text, key) {
-  let iv = ZERO, ct = text, usedIv = false;
+// Decrypt a wire value; iv/tag are embedded in the envelope. Returns { plaintext, scheme }.
+function decEnvelope(text, key, gid) {
+  const bkey = Buffer.from(key.substring(0, 32), 'utf8');
+  let scheme = 'legacy', iv = ZERO, ct = text, tag = null, alg = null;
   try {
     const p = JSON.parse(text);
     if (typeof p === 'string') { ct = p; }
     else if (p && typeof p === 'object' && !Array.isArray(p) && p.message != null) {
-      ct = p.message;
-      if (p.iv != null) { iv = Buffer.from(p.iv, 'base64'); usedIv = true; }
+      ct = p.message; alg = p.alg;
+      if (p.iv != null) iv = Buffer.from(p.iv, 'base64');
+      if (p.tag != null) tag = Buffer.from(p.tag, 'base64');
     }
   } catch (e) { /* raw base64, legacy */ }
-  const bkey = Buffer.from(key.substring(0, 32), 'utf8');
+  if (alg === 'gcm') {
+    scheme = 'gcm';
+    const d = crypto.createDecipheriv('aes-256-gcm', bkey, iv);
+    d.setAAD(Buffer.from(gid, 'utf8'));
+    d.setAuthTag(tag);
+    return { plaintext: d.update(ct, 'base64', 'utf8') + d.final('utf8'), scheme };
+  }
+  if (iv !== ZERO) scheme = 'cbc-iv';
   const d = crypto.createDecipheriv(ALGO, bkey, iv);
-  return { plaintext: d.update(ct, 'base64', 'utf8') + d.final('utf8'), usedIv };
+  return { plaintext: d.update(ct, 'base64', 'utf8') + d.final('utf8'), scheme };
 }
 // Response may be compressed (compressMode); best-effort inflate for display.
 function maybeInflate(s) {
@@ -104,7 +124,7 @@ function maybeInflate(s) {
     process.exit(1);
   }
 
-  const modeLabel = useIV ? 'random IV (--iv)' : 'legacy zero IV';
+  const scheme = useGCM ? 'gcm' : useIV ? 'cbc-iv' : 'legacy';
 
   const id = 'ivtest-' + Date.now();
   const plaintext = JSON.stringify({
@@ -115,13 +135,11 @@ function maybeInflate(s) {
     }
   });
 
-  // IV (when used) is embedded in the message envelope; no top-level iv field.
-  const reqIvBuf = useIV ? crypto.randomBytes(16) : null;
-  const body = { message: enc(plaintext, key, reqIvBuf) };
+  // iv/tag (when used) are embedded in the message envelope; no top-level fields.
+  const body = { message: enc(plaintext, key, scheme, gid) };
 
   console.log('== REQUEST ==');
-  console.log('mode        :', modeLabel);
-  console.log('sending     :', useIV ? 'random IV embedded in { iv, message } envelope' : 'legacy zero IV, bare base64');
+  console.log('scheme      :', scheme);
   console.log('key (masked):', key.slice(0, 8) + '...(' + key.length + ' chars)');
   console.log('endpoint    : POST http://127.0.0.1:' + PORT + '/v1/encipher/message/' + gid);
 
@@ -140,11 +158,11 @@ function maybeInflate(s) {
   if (!reply) { console.log('raw reply   :', res.body.slice(0, 300)); process.exit(0); }
 
   if (reply.message) {
-    let out, replyUsedIv = false;
-    try { const r = decEnvelope(reply.message, key); out = maybeInflate(r.plaintext); replyUsedIv = r.usedIv; }
+    let out, replyScheme = '?';
+    try { const r = decEnvelope(reply.message, key, gid); out = maybeInflate(r.plaintext); replyScheme = r.scheme; }
     catch (e) { out = '<decrypt failed: ' + e.message + '>'; }
-    console.log('reply embeds iv:', replyUsedIv);
-    console.log('>> IV USAGE : box is ' + (replyUsedIv ? 'USING a per-request IV (new scheme)' : 'NOT using IV (legacy zero IV)'));
+    console.log('reply scheme:', replyScheme);
+    console.log('>> box replied with:', replyScheme, replyScheme === scheme ? '(mirrors request)' : '(does NOT mirror request!)');
     console.log('== DECRYPTED REPLY (first 400 chars) ==');
     console.log(out.slice(0, 400));
   } else {

--- a/sensor/Guardian.js
+++ b/sensor/Guardian.js
@@ -32,7 +32,6 @@ const CloudWrapper = require('../api/lib/CloudWrapper.js');
 const cw = new CloudWrapper();
 
 const zlib = require('zlib');
-const crypto = require('crypto');
 const deflateAsync = util.promisify(zlib.deflate);
 const rp = require('request-promise');
 
@@ -668,13 +667,13 @@ module.exports = class {
       const encryptedMessage = message.message;
       const replyid = message.replyid; // replyid will not encrypted
       let response, decryptedMessage, code = 200, encryptedResponse;
-      // The IV (if any) is embedded in the message envelope ({ iv, message }).
-      // decryptRequest reports usedIv so we can echo a fresh IV on the reply.
-      let replyIVBuf = null;
+      // decryptRequest reports the request scheme (gcm/cbc-iv/legacy) so the
+      // reply mirrors it; the iv/tag travel inside the message envelope.
+      let replyScheme = 'legacy';
       try {
-        const { decrypted, usedIv } = await cw.getCloud().decryptRequest(gid, encryptedMessage);
+        const { decrypted, scheme } = await cw.getCloud().decryptRequest(gid, encryptedMessage);
         decryptedMessage = decrypted;
-        replyIVBuf = usedIv ? crypto.randomBytes(16) : null;
+        replyScheme = scheme;
         decryptedMessage.mtype = decryptedMessage.message.mtype;
         const obj = decryptedMessage.message.obj;
         const item = obj.data.item;
@@ -707,7 +706,7 @@ module.exports = class {
           compressMode: 1,
           data: output.toString('base64')
         });
-        encryptedResponse = await cw.getCloud().encryptResponse(gid, compressedResponse, replyIVBuf);
+        encryptedResponse = await cw.getCloud().encryptResponse(gid, compressedResponse, replyScheme);
       } catch (err) {
         log.warn(`Process web message error`, err);
         if (err && err.message == "decrypt_error") {

--- a/test/test_encipher_iv.js
+++ b/test/test_encipher_iv.js
@@ -140,5 +140,18 @@ describe('encipher per-request IV', function () {
       expect(ept._parseEnvelope(JSON.stringify({})).invalid).to.equal(true);
       expect(ept._parseEnvelope(JSON.stringify({ iv: 'AA==' })).invalid).to.equal(true);
     });
+    it('accepts an already-parsed object (message sent as a nested object)', () => {
+      const e = ept._parseEnvelope({ iv: 'AA==', message: 'BB' });
+      expect(e.iv).to.equal('AA==');
+      expect(e.ct).to.equal('BB');
+    });
+  });
+
+  describe('lenient message shape', () => {
+    it('decrypt accepts message as a nested object, not just a JSON string', () => {
+      const env = JSON.parse(ept.encrypt(msg, key, crypto.randomBytes(16))); // { iv, message } object
+      expect(env).to.be.an('object');
+      expect(ept.decrypt(env, key)).to.equal(msg);
+    });
   });
 });

--- a/test/test_encipher_iv.js
+++ b/test/test_encipher_iv.js
@@ -140,5 +140,56 @@ describe('encipher per-request IV', function () {
       expect(ept._parseEnvelope(JSON.stringify({})).invalid).to.equal(true);
       expect(ept._parseEnvelope(JSON.stringify({ iv: 'AA==' })).invalid).to.equal(true);
     });
+    it('{ alg:"gcm", iv, message, tag } -> surfaces alg + tag', () => {
+      const e = ept._parseEnvelope(JSON.stringify({ alg: 'gcm', iv: 'AA==', message: 'BB', tag: 'CC==' }));
+      expect(e.alg).to.equal('gcm');
+      expect(e.tag).to.equal('CC==');
+      expect(ept._schemeOf(e)).to.equal('gcm');
+    });
+  });
+
+  describe('AES-256-GCM', () => {
+    const gid = 'group-1234';
+
+    it('round-trips via envelope (AAD = gid)', () => {
+      const env = ept._encryptGcm(msg, key, gid);
+      const o = JSON.parse(env);
+      expect(o.alg).to.equal('gcm');
+      expect(Buffer.from(o.iv, 'base64').length).to.equal(12);   // 12-byte nonce
+      expect(Buffer.from(o.tag, 'base64').length).to.equal(16);  // 16-byte tag
+      expect(ept.decrypt(env, key, gid)).to.equal(msg);
+    });
+
+    it('nonce is non-deterministic', () => {
+      expect(ept._encryptGcm(msg, key, gid)).to.not.equal(ept._encryptGcm(msg, key, gid));
+    });
+
+    it('rejects a tampered ciphertext (auth tag fails)', () => {
+      const o = JSON.parse(ept._encryptGcm(msg, key, gid));
+      const m = Buffer.from(o.message, 'base64'); m[0] ^= 1; o.message = m.toString('base64');
+      expect(ept.decrypt(JSON.stringify(o), key, gid)).to.equal(null);
+    });
+
+    it('rejects a tampered tag', () => {
+      const o = JSON.parse(ept._encryptGcm(msg, key, gid));
+      const t = Buffer.from(o.tag, 'base64'); t[0] ^= 1; o.tag = t.toString('base64');
+      expect(ept.decrypt(JSON.stringify(o), key, gid)).to.equal(null);
+    });
+
+    it('rejects a wrong AAD (different gid)', () => {
+      const env = ept._encryptGcm(msg, key, gid);
+      expect(ept.decrypt(env, key, 'other-gid')).to.equal(null);
+    });
+
+    it('rejects when gid is missing (no AAD)', () => {
+      const env = ept._encryptGcm(msg, key, gid);
+      expect(ept.decrypt(env, key)).to.equal(null);
+    });
+
+    it('rejects a wrong-length nonce / tag', () => {
+      expect(() => ept._normalizeNonce(crypto.randomBytes(16).toString('base64'))).to.throw();
+      expect(() => ept._normalizeTag(crypto.randomBytes(12).toString('base64'))).to.throw();
+      expect(ept._normalizeNonce(crypto.randomBytes(12)).length).to.equal(12);
+    });
   });
 });

--- a/test/test_encipher_iv.js
+++ b/test/test_encipher_iv.js
@@ -162,40 +162,43 @@ describe('encipher per-request IV', function () {
   });
 
   describe('AES-256-GCM', () => {
-    const gid = 'group-1234';
+    // AAD is the box's local gid (this.gid), not a per-call argument.
+    beforeEach(() => { ept.gid = 'group-1234'; });
 
-    it('round-trips via envelope (AAD = gid)', () => {
-      const env = ept._encryptGcm(msg, key, gid);
+    it('round-trips via envelope (AAD = local gid)', () => {
+      const env = ept._encryptGcm(msg, key);
       const o = JSON.parse(env);
       expect(o.alg).to.equal('gcm');
       expect(Buffer.from(o.iv, 'base64').length).to.equal(12);   // 12-byte nonce
       expect(Buffer.from(o.tag, 'base64').length).to.equal(16);  // 16-byte tag
-      expect(ept.decrypt(env, key, gid)).to.equal(msg);
+      expect(ept.decrypt(env, key)).to.equal(msg);
     });
 
     it('nonce is non-deterministic', () => {
-      expect(ept._encryptGcm(msg, key, gid)).to.not.equal(ept._encryptGcm(msg, key, gid));
+      expect(ept._encryptGcm(msg, key)).to.not.equal(ept._encryptGcm(msg, key));
     });
 
     it('rejects a tampered ciphertext (auth tag fails)', () => {
-      const o = JSON.parse(ept._encryptGcm(msg, key, gid));
+      const o = JSON.parse(ept._encryptGcm(msg, key));
       const m = Buffer.from(o.message, 'base64'); m[0] ^= 1; o.message = m.toString('base64');
-      expect(ept.decrypt(JSON.stringify(o), key, gid)).to.equal(null);
+      expect(ept.decrypt(JSON.stringify(o), key)).to.equal(null);
     });
 
     it('rejects a tampered tag', () => {
-      const o = JSON.parse(ept._encryptGcm(msg, key, gid));
+      const o = JSON.parse(ept._encryptGcm(msg, key));
       const t = Buffer.from(o.tag, 'base64'); t[0] ^= 1; o.tag = t.toString('base64');
-      expect(ept.decrypt(JSON.stringify(o), key, gid)).to.equal(null);
+      expect(ept.decrypt(JSON.stringify(o), key)).to.equal(null);
     });
 
-    it('rejects a wrong AAD (different gid)', () => {
-      const env = ept._encryptGcm(msg, key, gid);
-      expect(ept.decrypt(env, key, 'other-gid')).to.equal(null);
+    it('rejects when the local gid differs from the one used to encrypt (AAD mismatch)', () => {
+      const env = ept._encryptGcm(msg, key);   // encrypted with gid group-1234
+      ept.gid = 'other-gid';                    // box now on a different gid
+      expect(ept.decrypt(env, key)).to.equal(null);
     });
 
-    it('rejects when gid is missing (no AAD)', () => {
-      const env = ept._encryptGcm(msg, key, gid);
+    it('rejects when the local gid is unavailable', () => {
+      const env = ept._encryptGcm(msg, key);
+      ept.gid = null;
       expect(ept.decrypt(env, key)).to.equal(null);
     });
 


### PR DESCRIPTION
## What

Adds **AES-256-GCM authenticated encryption** to the box's netbot req/response path, closing the "unauthenticated CBC" gap. Chosen **per request by the client** and **mirrored by the box**, exactly like the IV scheme — the client indicates GCM in the message envelope, the box decrypts with GCM (verifying the tag) and encrypts the reply with GCM too.

Tracking issue: firewalla/firecommit#8658.

> **Stacked on #9298** (the `{ iv, message }` envelope). Base branch is `feat/netbot-per-request-iv`; review after / on top of #9298. Only the GCM diff shows here.

## Envelope

```json
{ "alg": "gcm", "iv": "<base64 12B nonce>", "message": "<base64 ciphertext>", "tag": "<base64 16B tag>" }
```
`alg` absent → CBC (bare base64 = zero IV; `{ iv, message }` = random-IV CBC). `alg:"gcm"` → GCM.

## Parameters (as agreed)
- **aes-256-gcm**, **12-byte** random nonce per message, **16-byte** tag.
- **AAD = `utf8(gid)`, using the box's own local group id** (cached from redis `sys:ept.gid` as `this.gid`), **not** the client-supplied gid in the request URL. Binds the group and cannot be influenced by URL tampering; prevents cross-group replay / reflection.
- **Key:** the existing 32-byte group key (no HKDF).

## Box changes (additive; CBC untouched)
- `_parseEnvelope` surfaces `alg`/`tag`; `_schemeOf(env)` → `gcm` | `cbc-iv` | `legacy`.
- `_decryptWithEnvelope(env, key)` — GCM branch validates 12B nonce + 16B tag, `setAAD(this._localGid())`, `setAuthTag`, `final()` (throws on tamper → null → 412). `_encryptGcm(text, key)` mints a fresh nonce and returns the envelope + tag. Neither takes a gid argument — both read the box's local gid via `_localGid()`.
- `decryptRequest` returns the request **scheme**; `encryptResponse(gid, body, scheme)` mirrors it. `Encryption.js` / `Guardian.js` thread the scheme (streaming stays legacy).
- Validators `_normalizeNonce` (12B) / `_normalizeTag` (16B).

## Backward compatibility
- Box-first, zero-risk: GCM used only when the client offers it; CBC/legacy untouched.
- Old box fails closed: sees a 12-byte `iv` as a CBC IV, `_normalizeIV` rejects it → 412. So clients only send GCM to a GCM-capable box (gate on box version — client's choice).
- **Downgrade caveat:** the box still accepts CBC for old clients, so a MITM could strip `alg` and force the unauthenticated path. Per-request mirroring can't fix that alone — closing it needs require-GCM capability pinning (separate hardening, noted in the issue).
- **Replay:** GCM stops tamper/forge but not pure replay; add `id`/timestamp to AAD or a replay window as a follow-up.

## Verification
- Unit tests (`test/test_encipher_iv.js`): GCM round-trip, tamper (ct/tag) → reject, wrong-AAD → reject, missing-local-gid → reject, nonce/tag length validation, scheme mirror.
- **Real class on a testbed:** 12/12 GCM assertions pass (tamper/tag/AAD-mismatch/missing-local-gid all rejected).
- **End-to-end on the testbed** via `scripts/test_encipher_iv.js`: legacy / `--iv` / `--gcm` all return 200 and the box **mirrors** each scheme (legacy→legacy, cbc-iv→cbc-iv, gcm→gcm).

## Files
`encipher/lib/encipherio.js`, `api/lib/Encryption.js`, `sensor/Guardian.js`, `scripts/test_encipher_iv.js`, `test/test_encipher_iv.js`.


## Update: AAD binds to the box's local gid
The GCM AAD is the box's **own** group id (loaded locally from `sys:ept.gid` and cached as `this.gid`), not `req.params.gid`. So authentication can't be influenced by the client-supplied URL gid. The client binds its AAD to the same shared gid (the group it's paired with), so legit traffic matches; an attacker altering the path can't affect the AAD. Assumes the box's primary group serves this endpoint (the normal single-group case); CBC/legacy are unaffected.
