### PR TITLE
fix bug, handling incomplete quic log

### DIFF
--- a/sensor/QuicLogPlugin.js
+++ b/sensor/QuicLogPlugin.js
@@ -96,7 +96,7 @@ class QuicLogPlugin extends Sensor {
   async _processQuicLog(line) {
     if (_.isEmpty(line)) return;
     // extract content after log prefix
-    const prefixIndex = line.indexOf(LOG_PREFIX);
+    const prefixIndex = line.lastIndexOf(LOG_PREFIX);
     if (prefixIndex < 0) return;
     const startIndex = prefixIndex + LOG_PREFIX.length;
     let endIndex = line.length;
@@ -107,7 +107,12 @@ class QuicLogPlugin extends Sensor {
     const content = line.substring(startIndex, endIndex).trim();
     if (!content || content.length == 0)
       return;
-    const obj = JSON.parse(content);
+    let obj;
+    try {
+      obj = JSON.parse(content);
+    } catch (e) {
+      log.info(`Failed to process quic log line: ${line} err: ${e}`);
+    }
     if (!obj || typeof obj !== 'object')
         return;
     const {src_addr, src_port, dst_addr, dst_port, protocol, hostname} = obj;
@@ -135,7 +140,6 @@ class QuicLogPlugin extends Sensor {
       await this._setConnEntryWithCache(connEntry);
     }
     this.localCache.set(connKey, true);
-    
   }
 
   async globalOn() { // relay on ACLAuditLogPlugin.globalOn

--- a/test/test_QuicLogPlugin.js
+++ b/test/test_QuicLogPlugin.js
@@ -151,4 +151,19 @@ describe('QuicLogPlugin._processQuicLog', function () {
     await plugin._processQuicLog(mkLine(2222));
     expect(plugin.connCache.length).to.equal(2);
   });
+
+  it('should recover the trailing entry from a line with two concatenated kernel messages (missing newline)', async () => {
+    // seen in production: a truncated message got glued to the next one without a newline in between
+    const line = 'Jul  9 12:32:25 localhost kernel: [6159943.347595] [FW_QUIC]:{"src_addr":"2409:871e:d00:40:4c00:88b1:30dd:ceca", "dst_addr":"240Jul  9 12:34:04 localhost kernel: [6160042.093775] [FW_QUIC]:{"src_addr":"192.168.201.111", "dst_addr":"52.222.244.51", "src_port":59282, "dst_port":443, "protocol":"UDP", "hostname":"www.figma.com"}';
+    await plugin._processQuicLog(line);
+
+    expect(plugin.connCache.length).to.equal(1);
+    const entry = plugin.connCache[0];
+    expect(entry.src).to.equal('192.168.201.111');
+    expect(entry.srcPort).to.equal(59282);
+    expect(entry.dst).to.equal('52.222.244.51');
+    expect(entry.dstPort).to.equal(443);
+    expect(entry.proto).to.equal('UDP');
+    expect(entry.data[Constants.REDIS_HKEY_CONN_HOST]).to.equal('www.figma.com');
+  });
 });


### PR DESCRIPTION
Add handling for the scenario involving an incomplete QUIC log followed by a complete log(might because of log rotation).