### PR TITLE
netbot: include the item in unsupported get/set action errors

### DIFF
--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -1156,7 +1156,7 @@ class netBot extends ControllerBot {
       case "autoUpgrade":
         return upgradeManager.setAutoUpgradeState(value)
       default:
-        throw new Error("Unsupported set action")
+        throw new Error("Unsupported set action: " + msg.data.item)
     }
   }
 
@@ -1897,7 +1897,7 @@ class netBot extends ControllerBot {
         return result
       }
       default:
-        throw new Error("unsupported action");
+        throw new Error("Unsupported get action: " + msg.data.item);
     }
   }
 


### PR DESCRIPTION
## What
The get/set message handlers threw a bare error with no context:
- `getHandler` (`controllers/netbot.js:1900`): `throw new Error("unsupported action")`
- `setHandler` (`:1159`): `throw new Error("Unsupported set action")`

So logs showed only `Error process message Error: unsupported action` with no indication of *which* request failed — e.g.:
```
ERROR Netbot: Error process message Error: unsupported action
    at netBot.getHandler (controllers/netbot.js:1900:15)
```

## Change
Append `msg.data.item` (the requested action) to both, matching the existing `cmdHandler` default (`"Unsupported cmd action: " + msg.data.item`). Now the log reads e.g. `Unsupported get action: <item>`, making it clear which get/set the app/MSP asked for.

Two-line change; no behavior change beyond the error message.