### PR TITLE
scripts: add update_member_name.js to preview encrypted member name

### DIFF
--- a/scripts/update_member_name.js
+++ b/scripts/update_member_name.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/*
+ * Show the encrypted "name" (account email) for a group member entry.
+ *
+ * Given a member eid and a new cleartext email, print the AES-encrypted
+ * value as it would be stored in symmetricKeys[].name in the Encipher
+ * cloud. Read-only / offline: it reuses the box's own EptCloud crypto and
+ * the group info cached in redis (sys:ept:me), never contacting the cloud.
+ *
+ * Run on the box, from the firewalla home:
+ *   cd /home/pi/firewalla
+ *   OPENSSL_CONF=/dev/null bin/node scripts/update_member_name.js <eid> "<new email>"
+ */
+'use strict';
+
+const cloud = require('../encipher');
+
+async function main() {
+  const eid = process.argv[2];
+  const newName = process.argv[3];
+
+  if (!eid || !newName) {
+    console.error('usage: node scripts/update_member_name.js <eid> "<new email>"');
+    process.exit(1);
+  }
+
+  const eptcloud = new cloud('netbot');
+  await eptcloud.loadKeys();
+  await eptcloud.reloadGroupInfoFromRedis();
+
+  const gid = Object.keys(eptcloud.groupCache)[0];
+  const cached = gid && eptcloud.groupCache[gid];
+  if (!cached) throw new Error('no group info cached in redis (sys:ept:me)');
+
+  const symmetricKey = cached.key; // decrypted group symmetric key
+  const entry = cached.group.symmetricKeys.find(k => k.eid === eid);
+  if (!entry) {
+    console.error(`eid ${eid} is not a member of group ${gid}. Members:`);
+    for (const k of cached.group.symmetricKeys) console.error('  ' + k.eid);
+    process.exit(1);
+  }
+
+  const oldName = entry.name ? eptcloud.decrypt(entry.name, symmetricKey) : '(none)';
+
+  console.log('gid           :', gid);
+  console.log('eid           :', eid);
+  console.log('old name      :', oldName);
+  console.log('new name      :', newName);
+  console.log('new encrypted :', eptcloud.encrypt(newName, symmetricKey));
+}
+
+main().then(() => process.exit(0)).catch(err => {
+  console.error('ERROR:', err && err.message ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds `scripts/update_member_name.js`, a small read-only helper that, given a group member `eid` and a new cleartext account email, prints the AES-encrypted value as it would be stored in the group's `symmetricKeys[].name` in the Encipher cloud.

```
cd /home/pi/firewalla
OPENSSL_CONF=/dev/null bin/node scripts/update_member_name.js <eid> "<new email>"
```

Output shape:
```
gid           : <gid>
eid           : <eid>
old name      : <current email>
new name      : <new email>
new encrypted : <base64 ciphertext>
```

## How

Reuses `EptCloud`'s own crypto (`loadKeys` + `reloadGroupInfoFromRedis`) and the group info cached in redis (`sys:ept:me`). It:

- loads the box RSA key and the cached group,
- recovers the decrypted group symmetric key,
- decrypts the member's current `name` for reference,
- AES-256-CBC encrypts the new email with the group key (same path as `EptCloud.encrypt`).

## Notes

- **Read-only and offline** — never contacts the cloud and writes nothing (no commit flag, no redis writes). Purely a preview/verification tool.
- Verified on a live box: re-encrypting an existing member's email reproduced the exact ciphertext stored in the cloud group record (deterministic because the legacy `encrypt` path uses a fixed IV).
- `OPENSSL_CONF=/dev/null` is needed on the box because node 12 trips over the system OpenSSL engine config.