### PR TITLE
ept: allow overriding member name (email) via sys:ept:memberEmails

### DIFF
--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -1152,6 +1152,13 @@ class netBot extends ControllerBot {
           throw new Error("rename failed")
         }
       }
+      case "eptMemberEmail": {
+        const { eid, email } = value;
+        if (!eid || !email)
+          throw { code: 400, msg: "both eid and email are required" };
+        await rclient.hsetAsync(Constants.REDIS_KEY_EPT_MEMBER_EMAILS, eid, email);
+        return
+      }
       case "intelAdvice": {
         const { target, ip, intel } = value
         intel.localIntel = await intelTool.getIntel(ip)

--- a/extension/ept/eptcloud.js
+++ b/extension/ept/eptcloud.js
@@ -51,8 +51,9 @@ class EptCloudExtension {
     //clear members info which is not in the group
     const names = (await rclient.hgetallAsync("sys:ept:memberNames")) || {};
     const lastVisits = (await rclient.hgetallAsync("sys:ept:member:lastvisit")) || {};
+    const emails = (await rclient.hgetallAsync(Constants.REDIS_KEY_EPT_MEMBER_EMAILS)) || {};
 
-    const allEids = new Set([...Object.keys(names), ...Object.keys(lastVisits)])
+    const allEids = new Set([...Object.keys(names), ...Object.keys(lastVisits), ...Object.keys(emails)])
     const clientsEidList = clients.map(client => client.eid);
     const eidsToDelete = Array.from(allEids).filter(eid => !clientsEidList.includes(eid));
 
@@ -60,6 +61,7 @@ class EptCloudExtension {
       log.info(`Deleting unpaired eid ${eid} from group ${gid}`);
       await rclient.hdelAsync("sys:ept:memberNames", eid);
       await rclient.hdelAsync("sys:ept:member:lastvisit", eid);
+      await rclient.hdelAsync(Constants.REDIS_KEY_EPT_MEMBER_EMAILS, eid);
 
       // sync op to msp
       const sl = require('../../sensor/APISensorLoader.js');

--- a/net2/Constants.js
+++ b/net2/Constants.js
@@ -47,6 +47,7 @@ module.exports = {
   PORT_DNS_TEST_SRC: 8855,
 
   REDIS_KEY_EID_REVOKE_SET: "sys:ept:members:revoked",
+  REDIS_KEY_EPT_MEMBER_EMAILS: "sys:ept:memberEmails",
   REDIS_KEY_GROUP_NAME: "groupName",
   REDIS_KEY_DDNS_UPDATE: "ddns:update",
   REDIS_KEY_CPU_USAGE: "cpu_usage_records",

--- a/net2/HostManager.js
+++ b/net2/HostManager.js
@@ -1391,8 +1391,16 @@ module.exports = class HostManager extends Monitorable {
 
       if(mm && mm.length > 0) {
         const names = await rclient.hgetallAsync("sys:ept:memberNames")
+        const emails = await rclient.hgetallAsync(Constants.REDIS_KEY_EPT_MEMBER_EMAILS)
         const lastVisits = await rclient.hgetallAsync("sys:ept:member:lastvisit")
         const history = await rclient.hgetallAsync("sys:ept:members:history")
+
+        if(emails) {
+          mm.forEach((m) => {
+            if (m.eid && emails[m.eid])
+              m.name = emails[m.eid]
+          })
+        }
 
         if(names) {
           mm.forEach((m) => {

--- a/sensor/EncipherPlugin.js
+++ b/sensor/EncipherPlugin.js
@@ -90,6 +90,7 @@ class EncipherPlugin extends Sensor {
     await this.deleteEidEntryFromLocalRedis(eid);
     await rclient.hdelAsync("sys:ept:memberNames", eid);
     await rclient.hdelAsync("sys:ept:member:lastvisit", eid);
+    await rclient.hdelAsync(Constants.REDIS_KEY_EPT_MEMBER_EMAILS, eid);
     await rclient.saddAsync(Constants.REDIS_KEY_EID_REVOKE_SET, eid);
 
     try {


### PR DESCRIPTION
## What

Adds a redis hash `sys:ept:memberEmails` (field = member `eid`, value = email) that overrides the cloud-snapshotted member name returned for group members. When an eid has an entry in this hash, that email is used instead of the `name` stored in `sys:ept:members`.

## Why

The member `name` in the Encipher group record is the account email, AES-encrypted and snapshotted at invite/re-key time, so it is effectively immutable without re-inviting the eid. This adds a local, box-side override so the email shown for a member can be updated without touching the cloud group record.

## Changes

- **net2/Constants.js** — add `REDIS_KEY_EPT_MEMBER_EMAILS: "sys:ept:memberEmails"`.
- **net2/HostManager.js** (`encipherMembersForInit`) — overlay the email onto `m.name` when the eid has an entry, so the existing `eptGroup` get API returns the overridden value. Applied the same way as the existing `memberNames`/`lastvisit` overlays.
- **controllers/netbot.js** (`setHandler`) — add an `eptMemberEmail` command taking `{ eid, email }` and writing it to the hash; rejects missing eid/email with a 400.
- **extension/ept/eptcloud.js** and **sensor/EncipherPlugin.js** — remove the eid's email entry on unpair/revoke, consistent with the existing cleanup of `memberNames` and `member:lastvisit` (and include the new hash's keys in the stale-eid sweep).

## API

Set the email for a member (local API, port 8834):

```
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"eid":"<EID>","email":"<new email>"}' \
  'http://localhost:8834/v1/encipher/simple?command=set&item=eptMemberEmail'
```

Read back (existing command; now reflects the override in each member's `name`):

```
curl -s 'http://localhost:8834/v1/encipher/simple?command=get&item=eptGroup'
```

## Verification

- `node --check` passes on all five changed files.
- Overlay logic unit-checked in isolation: an eid with an entry gets its `name` overridden, members without an entry are untouched, and `dName` (from `memberNames`) is still applied independently.
- Note: end-to-end verification on a live box (deploy + fireapi restart) was intentionally not performed here; the change mirrors the adjacent, already-proven `memberNames` overlay and set-command patterns.