### PR TITLE
fix bug, failed to read udp_tls module version

### DIFF
--- a/net2/KernelCrashMonitor.js
+++ b/net2/KernelCrashMonitor.js
@@ -79,13 +79,28 @@ async function waitForLockReleaseAndRefreshCache() {
   cachedShouldDisableUdpTls = crashInfo.shouldDisableUdpTls === true;
 }
 
-// parse "version:" and "srcversion:" lines from modinfo output
-async function getModuleVersion(koPathOrName) {
-  const result = await execFile('modinfo', [koPathOrName]).catch((err) => {
-    log.error("Failed to run modinfo for", koPathOrName, err.message);
+// parse "version:" and "srcversion:" lines from modinfo output.
+// try `modinfo koPath` first; when that fails (koPath may not exist yet), fall
+// back to `modinfo modName` so the version can still be resolved from an
+// already-loaded/installed module by name.
+async function getModuleVersion(modName, koPath) {
+  let result = null;
+  if (koPath) {
+    result = await execFile('modinfo', [koPath]).catch((err) => {
+      log.debug("Failed to run modinfo for", koPath, err.message);
+      return null;
+    });
+  }
+  if (!result && modName) {
+    result = await execFile('modinfo', [modName]).catch((err) => {
+      log.debug("Failed to run modinfo for", modName, err.message);
+      return null;
+    });
+  }
+  if (!result) {
+    log.warn("Failed to get module version for", modName, koPath);
     return null;
-  });
-  if (!result) return null;
+  }
 
   let version = '';
   let srcversion = '';
@@ -159,8 +174,9 @@ async function archiveAndClearPstore(crashTS) {
   }
 }
 
-// Called at FireMain and FireApi startup. koPath is the path to xt_udp_tls.ko (may not exist yet).
-async function checkPstoreAndUpdateRedis(koPath) {
+// Called at FireMain and FireApi startup. modName is the module name (e.g. "xt_udp_tls")
+// and koPath is the path to xt_udp_tls.ko (may not exist yet).
+async function checkPstoreAndUpdateRedis(modName, koPath) {
   const crashInfo = await readCrashInfo().catch((err) => {
     log.error("Error in checkPstoreAndUpdateRedis reading crash info:", err.message);
     return {};
@@ -184,7 +200,7 @@ async function checkPstoreAndUpdateRedis(koPath) {
     const lines = findResult.stdout.trim().split('\n').filter(Boolean)
       .sort((a, b) => parseFloat(b) - parseFloat(a));
 
-    const currentVersion = await getModuleVersion(koPath).catch(() => null);
+    const currentVersion = await getModuleVersion(modName, koPath).catch(() => null);
     const storedVersion = crashInfo.udpModuleVersion;
     let updateCrashInfoNeed = false;
     let dumpPstoreNeeded = false;
@@ -300,10 +316,11 @@ function shouldDisableUdpTls() {
 }
 
 // Called by Platform.installTLSModule after xt_udp_tls is successfully loaded.
-// koPath is the .ko file path if insmod was used, otherwise pass the module name.
-async function onUdpTlsModuleLoaded(koPathOrName) {
+// modName is the module name (e.g. "xt_udp_tls"); koPath is the .ko file path if
+// insmod was used (may be null when loaded by name).
+async function onUdpTlsModuleLoaded(modName, koPath) {
   try {
-    const version = await getModuleVersion(koPathOrName || 'xt_udp_tls');
+    const version = await getModuleVersion(modName || 'xt_udp_tls', koPath);
     const crashInfo = await readCrashInfo();
 
     if (version) {

--- a/net2/main.js
+++ b/net2/main.js
@@ -87,8 +87,8 @@ async function run0() {
 
   // check pstore for recent kernel crashes and update Redis before any module loading
   const kernelCrashMonitor = require('./KernelCrashMonitor.js');
-  const udpTlsKoPath = await platform.getTlsKoPath('xt_udp_tls').catch(() => 'xt_udp_tls');
-  await kernelCrashMonitor.checkPstoreAndUpdateRedis(udpTlsKoPath);
+  const udpTlsKoPath = await platform.getTlsKoPath('xt_udp_tls').catch(() => null);
+  await kernelCrashMonitor.checkPstoreAndUpdateRedis('xt_udp_tls', udpTlsKoPath);
 
   const isModeConfigured = await mode.isModeConfigured();
   await sysManager.waitTillInitialized();

--- a/platform/Platform.js
+++ b/platform/Platform.js
@@ -507,7 +507,7 @@ class Platform {
       if (!kernelCrashMonitor) {
         kernelCrashMonitor = require('../net2/KernelCrashMonitor.js');
       }
-      await kernelCrashMonitor.onUdpTlsModuleLoaded(koExists ? koPath : 'xt_udp_tls');
+      await kernelCrashMonitor.onUdpTlsModuleLoaded('xt_udp_tls', koExists ? koPath : null);
     }
   }
   async installTLSModules() {

--- a/platform/platform.sh
+++ b/platform/platform.sh
@@ -285,7 +285,7 @@ function installTLSModule() {
     [[ -z "$crash_info" ]] && crash_info='{}'
     updated=$(echo "$crash_info" | jq \
       --arg v "$version" --arg sv "$srcversion" \
-      '.udpModuleVersion = {"version": $v, "srcversion": $sv} | .shouldDisableUdpTls = false' 2>/dev/null)
+      '.udpModuleVersion = {"version": $v, "srcversion": $sv} | .shouldDisableUdpTls = false' 2>/dev/null | jq -c )
     [[ -n "$updated" ]] && redis-cli set kernel_crash_info "$updated" > /dev/null
   fi
   return

--- a/test/test_KernelCrashMonitor.js
+++ b/test/test_KernelCrashMonitor.js
@@ -159,7 +159,7 @@ describe('KernelCrashMonitor', function () {
       const { execFile } = makeExecFile({ dmesgFindOutput: '' });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       expect(kcm.shouldDisableUdpTls()).to.be.true;
     });
@@ -169,10 +169,10 @@ describe('KernelCrashMonitor', function () {
       const { execFile } = makeExecFile({ dmesgFindOutput: '', modinfoOutput: modinfoStdout('1.0', 'abc') });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
       expect(kcm.shouldDisableUdpTls()).to.be.true;
 
-      await kcm.onUdpTlsModuleLoaded('/lib/modules/xt_udp_tls.ko');
+      await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
       expect(kcm.shouldDisableUdpTls()).to.be.false;
     });
   });
@@ -185,7 +185,7 @@ describe('KernelCrashMonitor', function () {
       const { execFile } = makeExecFile({ modinfoOutput: modinfoStdout('1.0', 'abc123') });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.onUdpTlsModuleLoaded('/lib/modules/xt_udp_tls.ko');
+      await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.udpModuleVersion).to.deep.equal({ version: '1.0', srcversion: 'abc123' });
@@ -199,6 +199,22 @@ describe('KernelCrashMonitor', function () {
       await kcm.onUdpTlsModuleLoaded();
 
       expect(execLog.some(c => c === 'modinfo xt_udp_tls')).to.be.true;
+    });
+
+    it('falls back to `modinfo <modName>` when modinfo on the koPath fails', async function () {
+      const { execFile, execLog } = makeExecFile({
+        modinfoOutput: modinfoStdout('3.0', 'xyz789'),
+        failOn: (cmd) => cmd === 'modinfo /lib/modules/xt_udp_tls.ko',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      // tried the koPath first, then fell back to the module name
+      expect(execLog).to.include('modinfo /lib/modules/xt_udp_tls.ko');
+      expect(execLog).to.include('modinfo xt_udp_tls');
+      const info = await kcm.getCrashInfo();
+      expect(info.udpModuleVersion).to.deep.equal({ version: '3.0', srcversion: 'xyz789' });
     });
 
     it('still clears shouldDisableUdpTls when modinfo fails, without clobbering stored version', async function () {
@@ -233,7 +249,7 @@ describe('KernelCrashMonitor', function () {
       const { execFile, execLog } = makeExecFile({ dmesgFindOutput: '' });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.crashesCount).to.be.undefined;
@@ -250,7 +266,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.crashesCount).to.be.undefined;
@@ -268,7 +284,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.crashesCount).to.be.undefined;
@@ -286,7 +302,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.lastCrashTS).to.equal(300);
@@ -309,7 +325,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.shouldDisableUdpTls).to.not.equal(true);
@@ -329,7 +345,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.shouldDisableUdpTls).to.be.true;
@@ -347,7 +363,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.crashesCount).to.equal(1);
@@ -365,7 +381,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.crashesCount).to.equal(2);
@@ -385,7 +401,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       expect((await kcm.getCrashInfo()).lastCrashTS).to.equal(900);
     });
@@ -402,7 +418,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.shouldDisableUdpTls).to.be.false;
@@ -421,7 +437,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.shouldDisableUdpTls).to.be.true;
@@ -439,7 +455,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
       expect(info.shouldDisableUdpTls).to.be.true;
@@ -454,7 +470,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       expect(execLog.some(c => c === `sudo rm -rf ${PSTORE_ARCHIVE_PATH}/100`)).to.be.true;
       expect(execLog.some(c => c === `sudo rm -rf ${PSTORE_ARCHIVE_PATH}/200`)).to.be.false;
@@ -471,7 +487,7 @@ describe('KernelCrashMonitor', function () {
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
       expect(kcm._logs.error.some(m => m.includes('archive/clear pstore'))).to.be.true;
     });
 
@@ -496,7 +512,7 @@ describe('KernelCrashMonitor', function () {
         return origGet(key);
       };
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       // The losing process must observe the winner's decision, not the stale false.
       expect(kcm.shouldDisableUdpTls()).to.be.true;
@@ -512,7 +528,7 @@ describe('KernelCrashMonitor', function () {
       };
       const kcm = loadKCM(brokenRedis, execFile);
 
-      await kcm.checkPstoreAndUpdateRedis('/lib/modules/xt_udp_tls.ko');
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
       expect(kcm._logs.error.some(m => m.includes('checkPstoreAndUpdateRedis'))).to.be.true;
     });
   });


### PR DESCRIPTION
Fixed issue could not read version when the udp_tls module was located in the system's default path.