### PR TITLE
Update firestatus.yml

### DIFF
--- a/platform/goldplus2/files/firestatus.yml
+++ b/platform/goldplus2/files/firestatus.yml
@@ -5,32 +5,33 @@ leds:
   - /sys/class/leds/status:blue/trigger
   - /sys/class/leds/status:red/trigger
   - /sys/class/leds/status:green/trigger
+  - /sys/class/leds/sfp:speed:orange/trigger
 states:
   - state: force_blue_on
-    leds: ["default-on", "none", "none"]
+    leds: ["default-on", "none", "none", "netdev"]
   - state: force_red_on
-    leds: ["none", "default-on", "none"]
+    leds: ["none", "default-on", "none", "netdev"]
   - state: force_off
-    leds: ["none", "none", "none"]
+    leds: ["none", "none", "none", "netdev"]
   - state: critical_error
-    leds: ["none", "default-on", "none"]
+    leds: ["none", "default-on", "none", "netdev"]
   - state: reset
-    leds: ["none", "timer", "none"]
+    leds: ["none", "timer", "none", "netdev"]
   - state: network_down
-    leds: ["none", "timer", "none"]
+    leds: ["none", "timer", "none", "netdev"]
   - state: bluetooth_connected
-    leds: ["heartbeat", "none", "none"]
+    leds: ["heartbeat", "none", "none", "netdev"]
   - state: writing_disk
-    leds: ["heartbeat", "none", "none"]
+    leds: ["heartbeat", "none", "none", "netdev"]
   - state: booted
-    leds: ["default-on", "none", "none"]
+    leds: ["default-on", "none", "none", "default-on"]
   - state: booting
-    leds: ["timer", "none", "none"]
+    leds: ["timer", "none", "none", "timer"]
   - state: normal_visible
-    leds: ["default-on", "none", "none"]
+    leds: ["default-on", "none", "none", "netdev"]
   - state: ready_for_pairing
-    leds: ["none", "none", "none"]
+    leds: ["none", "none", "none", "netdev"]
   - state: normal
-    leds: ["none", "none", "none"]
+    leds: ["none", "none", "none", "netdev"]
   - state: force_green_on
-    leds: ["none", "none", "default-on"]
+    leds: ["none", "none", "default-on", "netdev"]


### PR DESCRIPTION
## Summary
Bring the GoldPlus2 SFP port's orange speed LED (`sfp:speed:orange`) under firestatus management and define its behavior for every device state. Previously firestatus only drove the three status LEDs (blue/red/green); the SFP LED was unmanaged.

## Changes (`platform/goldplus2/files/firestatus.yml`)
- Register `/sys/class/leds/sfp:speed:orange/trigger` as a 4th managed LED.
- Add its trigger to every state (the appended 4th value in each `leds` array):
  - **booting** → `timer` (blinks while booting)
  - **booted** → `default-on` (solid on once up)
  - **all other states** → `netdev` (follows SFP link/activity)

## Effect
The SFP LED now tracks boot progress and then reflects SFP link/activity, consistent with the device's status state. The three existing status LEDs are unchanged.