### PR TITLE
[beta_23_0] goldplus2: add SFP speed LED to firestatus states

### DIFF
--- a/platform/goldplus2/files/firestatus.yml
+++ b/platform/goldplus2/files/firestatus.yml
@@ -5,32 +5,33 @@ leds:
   - /sys/class/leds/status:blue/trigger
   - /sys/class/leds/status:red/trigger
   - /sys/class/leds/status:green/trigger
+  - /sys/class/leds/sfp:speed:orange/trigger
 states:
   - state: force_blue_on
-    leds: ["default-on", "none", "none"]
+    leds: ["default-on", "none", "none", "netdev"]
   - state: force_red_on
-    leds: ["none", "default-on", "none"]
+    leds: ["none", "default-on", "none", "netdev"]
   - state: force_off
-    leds: ["none", "none", "none"]
+    leds: ["none", "none", "none", "netdev"]
   - state: critical_error
-    leds: ["none", "default-on", "none"]
+    leds: ["none", "default-on", "none", "netdev"]
   - state: reset
-    leds: ["none", "timer", "none"]
+    leds: ["none", "timer", "none", "netdev"]
   - state: network_down
-    leds: ["none", "timer", "none"]
+    leds: ["none", "timer", "none", "netdev"]
   - state: bluetooth_connected
-    leds: ["heartbeat", "none", "none"]
+    leds: ["heartbeat", "none", "none", "netdev"]
   - state: writing_disk
-    leds: ["heartbeat", "none", "none"]
+    leds: ["heartbeat", "none", "none", "netdev"]
   - state: booted
-    leds: ["default-on", "none", "none"]
+    leds: ["default-on", "none", "none", "default-on"]
   - state: booting
-    leds: ["timer", "none", "none"]
+    leds: ["timer", "none", "none", "timer"]
   - state: normal_visible
-    leds: ["default-on", "none", "none"]
+    leds: ["default-on", "none", "none", "netdev"]
   - state: ready_for_pairing
-    leds: ["none", "none", "none"]
+    leds: ["none", "none", "none", "netdev"]
   - state: normal
-    leds: ["none", "none", "none"]
+    leds: ["none", "none", "none", "netdev"]
   - state: force_green_on
-    leds: ["none", "none", "default-on"]
+    leds: ["none", "none", "default-on", "netdev"]


### PR DESCRIPTION
Cherry-pick of #9390 (commit `a0e6cfa8f`) onto `beta_23_0`. Brings the GoldPlus2 SFP orange speed LED (`sfp:speed:orange`) under firestatus with per-state triggers (`timer` booting, `default-on` booted, `netdev` otherwise). Applies cleanly — `beta_23_0`'s firestatus.yml matched the commit's parent.

(cherry picked from commit a0e6cfa8f861f06cacf1a416cd89abae47d6c129)