### PR TITLE
monitor RSPAN VLAN traffic in Zeek with dedup

### DIFF
--- a/net2/BroControl.js
+++ b/net2/BroControl.js
@@ -24,6 +24,7 @@ const Promise = require('bluebird');
 const fs = require('fs');
 Promise.promisifyAll(fs);
 const _ = require('lodash');
+const Constants = require('./Constants.js');
 const platform = require('../platform/PlatformLoader.js').getPlatform();
 const BRO_PROC_NAME = platform.getBroProcName();
 
@@ -75,9 +76,10 @@ class BroControl {
       // subsequent filters in restrict_filters will be applied properly
       if (intfType === "1")
         workerScript.push(`redef capture_filters += [["shift-vlan-offset"] = "(not ether proto 0x8100) or (ether proto 0x8100 and vlan)"];`);
+      const workerId = intf === Constants.INTF_PCAP_RSPAN ? "worker-rspan" : `worker-${index++}`;
       workerCfg.push(
         `\n`,
-        `[worker-${index++}]\n`,
+        `[${workerId}]\n`,
         `type=worker\n`,
         `host=localhost\n`,
         `interface=${intf}\n`,

--- a/net2/BroDetect.js
+++ b/net2/BroDetect.js
@@ -88,6 +88,7 @@ const { getUniqueTs, extractIP } = require('./FlowUtil.js')
 
 const LRU = require('lru-cache');
 const Constants = require('./Constants.js');
+const FireRouter = require('./FireRouter.js');
 const DestIPFoundHook = require('../hook/DestIPFoundHook.js');
 const destIPFoundHook = new DestIPFoundHook();
 
@@ -160,6 +161,7 @@ class BroDetect {
     this.proxyConn = new LRU({max: PROXY_CONN_SIZE, maxAge: 60 * 1000});
     this.dnsCache = new LRU({max: DNS_CACHE_SIZE, maxAge: 3600 * 1000});
     this.bridgeLocalFlow = new LRU({max: 1000, maxAge: 10 * 1000});
+    this.sameNetworkFlowDedup = new LRU({max: 1000, maxAge: 180 * 1000});
     this.oIntfCache = new LRU({max: 1000, maxAge: 10 * 1000}); // for rate limited A=C log
     this.dnsCount = 0
     this.dnsHit = 0
@@ -731,14 +733,48 @@ class BroDetect {
   }
 
   // Decide whether a same-network local flow should be dropped.
-  // Different stpPort => router is the common ancestor: keep zeek's own flow (bridge=false),
-  // drop the AP/switch duplicate (bridge=true).
-  // Same or unknown stpPort => switch/AP is the common ancestor: keep only the bridge flow,
-  // drop zeek's copy (current behavior).
-  _dropLocalSameNetworkFlow(bridge, srcStpPort, dstStpPort) {
-    if (srcStpPort && dstStpPort && srcStpPort !== dstStpPort)
-      return bridge;   // different physical port — only drop the bridge copy
-    return !bridge;    // same/unknown port — only drop the zeek (non-bridge) copy
+  //
+  // Three possible traffic sources: normal zeek, RSPAN zeek (isRspan), AP/switch bridge (bridge).
+  //
+  // Different stpPorts: the router is the common ancestor.
+  //   - Zeek sees the routed flow: keep.
+  //   - RSPAN or bridge see a mirrored/bridged copy: drop.
+  //
+  // Same or unknown stpPorts: the switch/AP is the common ancestor.
+  //   - If either host is wireless: AP bridge is the authoritative source (full-duplex view);
+  //     RSPAN only catches one direction for wireless → drop RSPAN, keep bridge.
+  //   - If both hosts are wired: first source to register the 5-tuple wins (LRU dedup).
+  //   - Zeek (non-bridge, non-rspan) on same segment: invalid, drop.
+  //
+  // srcHost / dstHost and flowKey are optional (omitted at the early gate).
+  _dropLocalSameNetworkFlow(bridge, isRspan, srcStpPort, dstStpPort, srcHost = null, dstHost = null, flowKey = null) {
+    if (srcStpPort && dstStpPort && (srcStpPort !== dstStpPort || srcStpPort.startsWith("wlan"))) {
+      // different physical port or same native Wi-Fi AP interface — router is common ancestor; RSPAN/bridge copies are redundant
+      return isRspan || bridge;
+    }
+    // same or unknown stp port
+    if (!isRspan && !bridge) {
+      // plain zeek on same-network segment and same ethernet port — should not be seen by zeek directly
+      return true;
+    }
+    // RSPAN or bridge (AP/switch) traffic
+    if (srcHost || dstHost) {
+      const srcIsWireless = srcHost && srcHost.isWirelessDevice && srcHost.isWirelessDevice();
+      const dstIsWireless = dstHost && dstHost.isWirelessDevice && dstHost.isWirelessDevice();
+      if (srcIsWireless || dstIsWireless) {
+        // at least one wireless device: AP has full visibility; RSPAN only sees one direction
+        return isRspan;
+      }
+    }
+    // both wired (or unknown): first source to register the 5-tuple wins
+    if (flowKey) {
+      const source = isRspan ? 'rspan' : 'ap_switch';
+      if (this.sameNetworkFlowDedup.has(flowKey)) {
+        return this.sameNetworkFlowDedup.get(flowKey) !== source; // drop if different source, keep if the same source
+      }
+      this.sameNetworkFlowDedup.set(flowKey, source);
+    }
+    return false;
   }
 
   async validateConnData(obj) {
@@ -969,6 +1005,8 @@ class BroDetect {
       const localResp = obj["local_resp"];
       let localFlow = false
       let bridge = obj["bridge"] || false;
+      const isRspan = obj.node === Constants.WORKER_ID_RSPAN ||
+        (obj.vlan != null && FireRouter.getRspanVids().has(Number(obj.vlan)));
 
       log.silly("ProcessingConnection:", obj.uid, orig, resp, obj['id.resp_p'],
         long ? 'long' : '', reverseLocal ? 'reverseLocal' : '');
@@ -1036,18 +1074,20 @@ class BroDetect {
 
       let intfInfo = sysManager.getInterfaceViaIP(lhost, fam);
       let dstIntfInfo = localFlow && sysManager.getInterfaceViaIP(dhost, fam);
-      // do not process traffic between devices in the same network unless bridge flag is set (from fwap) or integrated AP is enabled (orange platform)
+      // Direction-aware 5-tuple key used by the same-network dedup LRU.
+      const sameNetworkFlowKey = `${obj.proto}:${orig}:${orig_p}:${resp}:${resp_p}`;
+      // do not process traffic between devices in the same network unless bridge flag is set (from fwap)
       // stpPort refinement: if both hosts have different stpPorts the router is the common ancestor —
-      // keep zeek's own flow and drop the AP bridge duplicate (see _dropLocalSameNetworkFlow).
+      // keep zeek's own flow and drop the AP/RSPAN duplicate (see _dropLocalSameNetworkFlow).
       // When stpPort is unknown for either host, defer to the authoritative gate below after host
       // objects are fully resolved.
-      if (intfInfo && dstIntfInfo && intfInfo.uuid == dstIntfInfo.uuid && !await platform.hasIntegratedAPAssets()) {
+      if (intfInfo && dstIntfInfo && intfInfo.uuid == dstIntfInfo.uuid) {
         const srcHost = hostManager.getHostFast(lhost, fam);
         const dstHost = hostManager.getHostFast(dhost, fam);
         const srcStpPort = srcHost && srcHost.getStpPort();
         const dstStpPort = dstHost && dstHost.getStpPort();
-        // Only early-drop when both stpPorts are known; otherwise defer to the authoritative gate.
-        if (srcStpPort && dstStpPort && this._dropLocalSameNetworkFlow(bridge, srcStpPort, dstStpPort))
+        // Only early-drop when both stpPorts are known; otherwise defer to the authoritative gate. Only ethernet devices have stpPort.
+        if (srcStpPort && dstStpPort && this._dropLocalSameNetworkFlow(bridge, isRspan, srcStpPort, dstStpPort))
           return;
       }
       // ignore multicast IP
@@ -1270,10 +1310,11 @@ class BroDetect {
             return;
           }
         }
-        if (intfInfo.uuid == dstIntfInfo.uuid && !await platform.hasIntegratedAPAssets() && !isIdentityIntf && !isDstIdentityIntf) {
+        if (intfInfo.uuid == dstIntfInfo.uuid && !isIdentityIntf && !isDstIdentityIntf) {
+          // only ethernet devices are considered here, VPN device is filtered by identity intf check
           const srcStpPort = monitorable && monitorable.getStpPort && monitorable.getStpPort();
           const dstStpPort = dstMonitorable && dstMonitorable.getStpPort && dstMonitorable.getStpPort();
-          if (this._dropLocalSameNetworkFlow(bridge, srcStpPort, dstStpPort))
+          if (this._dropLocalSameNetworkFlow(bridge, isRspan, srcStpPort, dstStpPort, monitorable, dstMonitorable, sameNetworkFlowKey))
             return;
         }
         if (obj.proto === "udp" && accounting.isBlockedDevice(dstMac)) {

--- a/net2/Constants.js
+++ b/net2/Constants.js
@@ -40,6 +40,8 @@ module.exports = {
 
   INTF_AP_CTRL: "wg_ap",
   INTF_PCAP_TAP: "ifb_pcap_tap",
+  INTF_PCAP_RSPAN: "ifb_pcap_rspan",
+  WORKER_ID_RSPAN: "worker-rspan",
 
   TRUST_IP_SET: "trust:ip",
   TRUST_DOMAIN_SET: "trust:domain",

--- a/net2/FireRouter.js
+++ b/net2/FireRouter.js
@@ -342,6 +342,8 @@ async function generateNetworkInfo() {
 let routerInterface = null
 let routerConfig = null
 let monitoringIntfNames = [];
+let rspanIntfNames = [];
+let rspanVids = new Set();
 let logicIntfNames = [];
 let wanIntfNames = null
 let defaultWanIntfName = null
@@ -478,6 +480,7 @@ class FireRouter {
   async init(first = false) {
     await lock.acquire(LOCK_INIT, async () => {
       const lastMonitoringIntfNames = monitoringIntfNames;
+      const lastRspanIntfNames = rspanIntfNames;
       const routingWans = [];
       const tcFilterRefreshNeeded = this.tcFilterRefreshNeeded;
       this.tcFilterRefreshNeeded = false;
@@ -508,6 +511,14 @@ class FireRouter {
             await delay(2000);
           }
         }
+
+        // extract RSPAN VLAN interface names and VIDs from config
+        rspanIntfNames = Object.keys(_.get(routerConfig, "interface.vlan", {}))
+          .filter(name => _.get(routerConfig, ["interface", "vlan", name, "rspan"]) === true);
+        rspanVids = new Set(rspanIntfNames
+          .map(name => _.get(routerConfig, ["interface", "vlan", name, "vid"]))
+          .filter(vid => vid != null)
+          .map(Number));
 
         // extract WAN interface names
         wanIntfNames = Object.values(intfNameMap)
@@ -757,6 +768,8 @@ class FireRouter {
 
       monitoringIntfNames.sort();
       lastMonitoringIntfNames.sort();
+      rspanIntfNames.sort();
+      lastRspanIntfNames.sort();
 
       // this will ensure SysManger on each process will be updated with correct info
       sem.emitLocalEvent({ type: Message.MSG_FW_FR_RELOADED });
@@ -765,10 +778,10 @@ class FireRouter {
       this.ready = true
 
       if (f.isMain()) {
-        if (pcapRestartNeeded || !platform.isFireRouterManaged() && first || !_.isEqual(monitoringIntfNames, lastMonitoringIntfNames)) {
+        if (pcapRestartNeeded || !platform.isFireRouterManaged() && first || !_.isEqual(monitoringIntfNames, lastMonitoringIntfNames) || !_.isEqual(rspanIntfNames, lastRspanIntfNames)) {
           sem.emitLocalEvent({ type: Message.MSG_PCAP_RESTART_NEEDED });
         }
-        if (first || tcFilterRefreshNeeded) {
+        if (first || tcFilterRefreshNeeded || !_.isEqual(rspanIntfNames, lastRspanIntfNames)) {
 
           const model = platform.getName();
           let qosNetworkType = 'lan';
@@ -783,6 +796,7 @@ class FireRouter {
             this.tcFilterRefreshNeeded = true;
           }
           this.scheduleResetPcapTap();
+          this.scheduleResetPcapRspan();
         }
         if (platform.isFireRouterManaged()) {
           // overall_wan_state event
@@ -853,6 +867,43 @@ class FireRouter {
       });
       await exec(`sudo tc filter add dev ${intf} egress u32 match u32 0 0 action mirred egress redirect dev ${Constants.INTF_PCAP_TAP}`).catch((err) => {
         log.error(`Failed to add pcap tap tc egress redirect filter for ${intf}`, err.message);
+      });
+    }
+  }
+
+  scheduleResetPcapRspan() {
+    if (this.resetPcapRspanTask) {
+      clearTimeout(this.resetPcapRspanTask);
+    }
+    this.resetPcapRspanTask = setTimeout(() => {
+      this.resetPcapRspan().catch((err) => {
+        log.error(`Failed to reset pcap rspan`, err.message);
+      });
+    }, 3000);
+  }
+
+  async resetPcapRspan() {
+    if (!platform.isIFBSupported()) {
+      return;
+    }
+    // clear tc filters on interfaces that are no longer RSPAN
+    const prevRspanIntfNames = this._rspanIntfNames || [];
+    for (const intf of prevRspanIntfNames) {
+      if (!rspanIntfNames.includes(intf)) {
+        await exec(`sudo tc qdisc del dev ${intf} clsact`).catch(() => {});
+      }
+    }
+    this._rspanIntfNames = rspanIntfNames.slice();
+    if (_.isEmpty(rspanIntfNames)) {
+      return;
+    }
+    for (const intf of rspanIntfNames) {
+      // add tc filter to redirect ingress traffic to the rspan ifb (RSPAN is receive-only, no egress redirect)
+      await exec(`sudo tc qdisc replace dev ${intf} clsact`).catch((err) => {
+        log.error(`Failed to create clsact qdisc on ${intf}`, err.message);
+      });
+      await exec(`sudo tc filter add dev ${intf} ingress u32 match u32 0 0 action mirred egress redirect dev ${Constants.INTF_PCAP_RSPAN}`).catch((err) => {
+        log.error(`Failed to add rspan tc ingress redirect filter for ${intf}`, err.message);
       });
     }
   }
@@ -985,6 +1036,14 @@ class FireRouter {
   // should always be an array
   getMonitoringIntfNames() {
     return JSON.parse(JSON.stringify(monitoringIntfNames))
+  }
+
+  getRspanIntfNames() {
+    return JSON.parse(JSON.stringify(rspanIntfNames));
+  }
+
+  getRspanVids() {
+    return new Set(rspanVids);
   }
 
   getWanIntfNames() {

--- a/net2/Host.js
+++ b/net2/Host.js
@@ -1354,6 +1354,18 @@ class Host extends Monitorable {
     return _.get(this.o, 'stpPort', null);
   }
 
+  setLastSeenOnWifi(ts) {
+    this._lastSeenOnWifi = ts;
+  }
+
+  getLastSeenOnWifi() {
+    return this._lastSeenOnWifi || null;
+  }
+
+  isWirelessDevice(ttlMs = 2 * 60 * 1000) {
+    return !!this._lastSeenOnWifi && (Date.now() - this._lastSeenOnWifi) < ttlMs;
+  }
+
   async _get24HoursInternetActivity() {
     const app = ["internet"];
     const mac = this.o.mac || this.getUniqueId();

--- a/scripts/prep/12_load_ifb_module.sh
+++ b/scripts/prep/12_load_ifb_module.sh
@@ -17,6 +17,8 @@ if [[ $IFB_SUPPORTED == "yes" ]]; then
   sudo ip link set ifb1 up &>/dev/null || true
   sudo ip link add ifb_pcap_tap type ifb &>/dev/null || true
   sudo ip link set ifb_pcap_tap up &>/dev/null || true
+  sudo ip link add ifb_pcap_rspan type ifb &>/dev/null || true
+  sudo ip link set ifb_pcap_rspan up &>/dev/null || true
 else
   sudo rmmod ifb &> /dev/null || true
 fi

--- a/sensor/APCMsgSensor.js
+++ b/sensor/APCMsgSensor.js
@@ -488,6 +488,10 @@ class APCMsgSensor extends Sensor {
     if (!host) {
       log.warn(`Unknown mac address ${mac}`);
     }
+
+    // Record in memory the last time this device was seen on a wireless network.
+    // BroDetect reads this to determine if a device is currently wireless.
+    if (host) host.setLastSeenOnWifi(Date.now());
     /* uncomment this if there is ssid based management in future releases
     const profile = this.ssidProfiles[uuid];
     if (!profile) {

--- a/sensor/PcapPlugin.js
+++ b/sensor/PcapPlugin.js
@@ -118,6 +118,7 @@ class PcapPlugin extends Sensor {
     if (platform.isFireRouterManaged()) {
       const intfNameMap = await FireRouter.getInterfaceAll();
       const pcapTapIntfs = platform.isIFBSupported() ? platform.getInterfacesRedirectedToPcapTap(intfNameMap) : {};
+      const rspanIntfNames = platform.isIFBSupported() ? FireRouter.getRspanIntfNames() : [];
       const monitoringInterfaces = FireRouter.getMonitoringIntfNames();
       const parentIntfOptions = {};
       const monitoringIntfOptions = {}
@@ -152,6 +153,23 @@ class PcapPlugin extends Sensor {
               maxPcapBufsize = pcapBufsize;
           }
           monitoringIntfOptions[intfName] = { pcapBufsize: maxPcapBufsize };
+        }
+      }
+      // RSPAN VLANs are not part of any monitored bridge, so they must be added explicitly to
+      // both option maps before the branch decision so the count comparison accounts for them.
+      // - monitoringIntfOptions gets ifb_pcap_rspan (all RSPAN traffic is redirected there via tc)
+      // - parentIntfOptions gets the physical parent of each RSPAN VLAN (e.g. eth1 for eth1.100)
+      if (!_.isEmpty(rspanIntfNames)) {
+        const rspanBufsize = Math.max(0, ...rspanIntfNames.map(n => this.getPcapBufsize(n.split('.')[0]) || 0)) || undefined;
+        monitoringIntfOptions[Constants.INTF_PCAP_RSPAN] = { pcapBufsize: rspanBufsize };
+        for (const rspanIntf of rspanIntfNames) {
+          const phyIntf = rspanIntf.split('.')[0];
+          const pcapBufsize = this.getPcapBufsize(phyIntf);
+          if (!parentIntfOptions[phyIntf]) {
+            parentIntfOptions[phyIntf] = { pcapBufsize };
+          } else {
+            parentIntfOptions[phyIntf].pcapBufsize = Math.max(parentIntfOptions[phyIntf].pcapBufsize, pcapBufsize);
+          }
         }
       }
       log.verbose("parentIntfOptions: ", parentIntfOptions);


### PR DESCRIPTION
- create ifb_pcap_rspan ifb device; redirect RSPAN VLAN ingress to it via tc mirred in FireRouter
- add ifb_pcap_rspan (or physical parent VLANs) to Zeek listen set in PcapPlugin; assign worker-rspan id in BroControl
- extend BroDetect same-network dedup to handle RSPAN as a third source alongside zeek and AP/switch bridge, using stpPort, wireless device status (isWirelessDevice), and LRU 5-tuple dedup
- track last-seen-on-wifi timestamp in Host/APCMsgSensor to support wireless device detection in dedup logic