### PR TITLE
Cherry-pick #9407 (Update release-on-merge.yml) to beta_23_0

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -9,6 +9,7 @@ on:
       - release_11_0
       - release_12_0
       - release_13_0
+      - release_14_0
       - beta_8_0
       - beta_9_0
       - beta_12_0
@@ -21,6 +22,8 @@ on:
       - beta_19_0
       - beta_20_0
       - beta_21_0
+      - beta_22_0
+      - beta_23_0
 
 permissions:
   contents: write


### PR DESCRIPTION
Cherry-picks #9407 onto `beta_23_0`: adds `release_14_0`, `beta_22_0`, `beta_23_0` to the release-on-merge workflow trigger branches.

https://claude.ai/code/session_01N9kRA2nznKyNZv6qEW5baX