### PR TITLE
fix bug, failed to detect module version on orange platform

### DIFF
--- a/control/install_iptables_setup.sh
+++ b/control/install_iptables_setup.sh
@@ -304,10 +304,7 @@ cat "$qos_file"
   echo 'COMMIT'
 } >> "$ip6tables_file"
 
-# Return 0 (need install/update) only when the module is supported on this platform AND
-# it is not loaded yet, or the loaded ko srcversion / installed .so checksum differs from
-# the bundled version. Return 1 otherwise so we can skip the disruptive rmmod/restore cycle.
-function tlsModuleNeedsUpdate() {
+function tlsModuleSupported() {
   local module_name=$1
   if [[ ${module_name} = "xt_tls" && ${XT_TLS_SUPPORTED} != "yes" ]]; then
     return 1
@@ -315,6 +312,17 @@ function tlsModuleNeedsUpdate() {
   if [[ ${module_name} = "xt_udp_tls" && ${XT_UDP_TLS_SUPPORTED} != "yes" ]]; then
     return 1
   fi
+  return 0
+}
+
+# Return 0 (needs a kernel module (re)load) only when the module is supported on this
+# platform AND it is not loaded yet, or the loaded ko differs from the bundled one.
+# Return 1 otherwise so we can skip the disruptive rmmod/restore cycle.
+# The userspace .so is checked separately by tlsSoNeedsUpdate: installing it does not
+# require reloading the module, so a .so-only change must not trigger the cycle.
+function tlsKoNeedsUpdate() {
+  local module_name=$1
+  tlsModuleSupported "${module_name}" || return 1
 
   # not loaded yet -> needs install
   if ! lsmod | grep -wq "${module_name}"; then
@@ -326,32 +334,39 @@ function tlsModuleNeedsUpdate() {
     return 0
   fi
 
-  # compare ko srcversion between the bundled ko and the currently loaded module
-  local ko_path ko_srcversion loaded_srcversion
+  # is the loaded module the one built from the bundled .ko? srcversion when the build has
+  # one, GNU build-id otherwise (see scripts/tls_module_id.sh). When neither side yields a
+  # comparable id we cannot tell, and leave the loaded module alone.
+  local ko_path
   ko_path=$(get_tls_ko_path "${module_name}")
   if [[ -f $ko_path ]]; then
-    ko_srcversion=$(modinfo "$ko_path" 2>/dev/null | awk '/^srcversion:/{print $2}')
-    loaded_srcversion=$(cat "/sys/module/${module_name}/srcversion" 2>/dev/null)
-    if [[ -n "$ko_srcversion" && "$ko_srcversion" != "$loaded_srcversion" ]]; then
-      return 0
-    fi
+    tls_module_matches_ko "${module_name}" "$ko_path"
+    case $? in
+      1)
+        echo "${module_name}: loaded module differs from the bundled ko, reload needed"
+        return 0
+        ;;
+      2)
+        echo "${module_name}: cannot determine whether the loaded module matches ${ko_path}, leaving it loaded"
+        ;;
+    esac
   fi
 
-  # compare the checksum between the bundled .so and the installed .so
-  local arch so_path so_path_alt src_so installed_so
-  arch=$(uname -m)
-  so_path=${FW_PLATFORM_CUR_DIR}/files/shared_objects/$(lsb_release -cs)/lib${module_name}.so
-  so_path_alt="/media/root-ro/usr/lib/${arch}-linux-gnu/xtables/lib${module_name}.so"
-  installed_so="/usr/lib/${arch}-linux-gnu/xtables/lib${module_name}.so"
-  if [[ -f $so_path ]]; then
-    src_so=$so_path
-  elif [[ -f $so_path_alt ]]; then
-    src_so=$so_path_alt
-  fi
-  if [[ -n "$src_so" ]]; then
-    if [[ ! -f $installed_so ]] || [[ $(sha256sum "$installed_so" | awk '{print $1}') != $(sha256sum "$src_so" | awk '{print $1}') ]]; then
-      return 0
-    fi
+  return 1
+}
+
+# Return 0 when the bundled userspace .so differs from the installed one (or is not
+# installed at all). Only the .so needs to be copied in that case.
+function tlsSoNeedsUpdate() {
+  local module_name=$1
+  tlsModuleSupported "${module_name}" || return 1
+
+  local src_so installed_so
+  src_so=$(get_tls_so_path "${module_name}")
+  installed_so=$(get_tls_so_installed_path "${module_name}")
+  [[ -n "$src_so" ]] || return 1
+  if [[ ! -f $installed_so ]] || [[ $(sha256sum "$installed_so" | awk '{print $1}') != $(sha256sum "$src_so" | awk '{print $1}') ]]; then
+    return 0
   fi
 
   return 1
@@ -360,24 +375,38 @@ function tlsModuleNeedsUpdate() {
 if [[ $XT_TLS_SUPPORTED == "yes" || $XT_UDP_TLS_SUPPORTED == "yes" ]]; then
   module_names=("tls" "udp_tls")
 
-  # only (re)install modules that are supported and whose ko version or .so checksum changed
-  modules_to_update=()
+  # ko and .so are checked separately: reloading the kernel module means rmmod plus a
+  # tls-rule-free iptables restore, while the .so is just a file copy. Modules whose ko
+  # changed are reloaded (installTLSModule installs their .so too), the rest only get
+  # their .so refreshed.
+  modules_to_reload=()
+  so_to_update=()
   for module_name in "${module_names[@]}"; do
-    if tlsModuleNeedsUpdate "xt_${module_name}"; then
-      modules_to_update+=("$module_name")
+    if tlsKoNeedsUpdate "xt_${module_name}"; then
+      modules_to_reload+=("$module_name")
+    elif tlsSoNeedsUpdate "xt_${module_name}"; then
+      so_to_update+=("$module_name")
     fi
   done
 
-  echo "Modules to update: ${modules_to_update[*]}"
+  echo "Modules to reload: ${modules_to_reload[*]}"
+  echo "Shared objects to update: ${so_to_update[*]}"
 
-  if [[ ${#modules_to_update[@]} -gt 0 ]]; then
+  # a .so-only change affects neither the loaded module nor existing rules, install it in
+  # place. Must happen before the iptables-restore at the end of this script, which may
+  # contain "-m tls" rules parsed by this .so.
+  for module_name in "${so_to_update[@]}"; do
+    installTLSSharedObject "xt_${module_name}"
+  done
+
+  if [[ ${#modules_to_reload[@]} -gt 0 ]]; then
     # existence of "-m tls" or "-m udp_tls" rules prevents kernel module from being updated, resotre with a tls-clean version first
     sudo iptables-save > "$iptables_file.orig"
     sudo ip6tables-save > "$ip6tables_file.orig"
 
     grep -vE "\-m tls|\-m udp_tls" "$iptables_file.orig" | sudo iptables-restore
     grep -vE "\-m tls|\-m udp_tls" "$ip6tables_file.orig" | sudo ip6tables-restore
-    for module_name in "${modules_to_update[@]}"; do
+    for module_name in "${modules_to_reload[@]}"; do
       if lsmod | grep -w "xt_${module_name}"; then
         sudo rmmod "xt_${module_name}"
         if [[ $? -eq 0 ]]; then

--- a/net2/KernelCrashMonitor.js
+++ b/net2/KernelCrashMonitor.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const log = require('./logger.js')(__filename);
+const f = require('./Firewalla.js');
 const rclient = require('../util/redis_manager.js').getRedisClient();
 const { execFile } = require('child-process-promise');
 const uuid = require('uuid');
@@ -79,39 +80,97 @@ async function waitForLockReleaseAndRefreshCache() {
   cachedShouldDisableUdpTls = crashInfo.shouldDisableUdpTls === true;
 }
 
-// parse "version:" and "srcversion:" lines from modinfo output.
-// try `modinfo koPath` first; when that fails (koPath may not exist yet), fall
-// back to `modinfo modName` so the version can still be resolved from an
-// already-loaded/installed module by name.
-async function getModuleVersion(modName, koPath) {
-  let result = null;
-  if (koPath) {
-    result = await execFile('modinfo', [koPath]).catch((err) => {
-      log.debug("Failed to run modinfo for", koPath, err.message);
-      return null;
-    });
-  }
-  if (!result && modName) {
-    result = await execFile('modinfo', [modName]).catch((err) => {
-      log.debug("Failed to run modinfo for", modName, err.message);
-      return null;
-    });
-  }
-  if (!result) {
-    log.warn("Failed to get module version for", modName, koPath);
+// version, srcversion and a type-tagged id ("buildid:..."/"srcversion:..."/"sha256:...") of
+// the bundled .ko, read out of the module image by scripts/tls_module_id.sh - shared with
+// platform.sh so both write the same values into udpModuleVersion. Returns null when the file
+// yields nothing at all.
+// Not modinfo(8): the .ko may be compressed, and gse's is xt_udp_tls.ko.<kernel checksum>
+// (or a .ko.<compiler> symlink to it), a name modinfo refuses.
+async function describeKo(koPath) {
+  if (!koPath) return null;
+  const script = `${f.getFirewallaHome()}/scripts/tls_module_id.sh`;
+  const result = await execFile(script, ['describe', koPath]).catch((err) => {
+    log.debug("Failed to describe", koPath, err.message);
     return null;
+  });
+  if (!result) return null;
+  const described = { version: '', srcversion: '', koId: '' };
+  for (const line of result.stdout.split('\n')) {
+    const idx = line.indexOf('=');
+    if (idx <= 0) continue;
+    const key = line.substring(0, idx);
+    const value = line.substring(idx + 1).trim();
+    if (key === 'version') described.version = value;
+    else if (key === 'srcversion') described.srcversion = value;
+    else if (key === 'id') described.koId = value;
   }
+  return described.koId ? described : null;
+}
 
+// What identifies the module we would load: taken from the bundled .ko when we have it, and
+// from modinfo about the loaded module when we do not (koPath may not exist yet, or the module
+// was loaded by name via modprobe).
+// Returns null when no identity at all could be determined (unknown, not "empty").
+async function getModuleVersion(modName, koPath) {
+  const described = await describeKo(koPath);
+  if (described) return described;
+
+  const result = modName && await execFile('modinfo', [modName]).catch((err) => {
+    log.debug("Failed to run modinfo for", modName, err.message);
+    return null;
+  });
   let version = '';
   let srcversion = '';
-  for (const line of result.stdout.split('\n')) {
+  for (const line of (result ? result.stdout : '').split('\n')) {
     if (line.startsWith('version:')) {
       version = line.split(':').slice(1).join(':').trim();
     } else if (line.startsWith('srcversion:')) {
       srcversion = line.split(':').slice(1).join(':').trim();
     }
   }
-  return { version, srcversion };
+  if (version || srcversion)
+    return { version, srcversion, koId: '' };
+
+  log.warn("Failed to get module version for", modName, koPath);
+  return null;
+}
+
+// version/srcversion/koId, with missing fields normalized to ''
+function identityFields(v) {
+  if (!v) return null;
+  return { version: v.version || '', srcversion: v.srcversion || '', koId: v.koId || '' };
+}
+
+function hasIdentity(v) {
+  const fields = identityFields(v);
+  return !!(fields && (fields.version || fields.srcversion || fields.koId));
+}
+
+// type of a tagged id ("buildid:abc" -> "buildid"), '' when it carries no tag
+function idType(id) {
+  const idx = id.indexOf(':');
+  return idx > 0 ? id.substring(0, idx) : '';
+}
+
+// Compare on the strongest field both records carry, koId first: it is normally a build id, so
+// it also catches a rebuild of unchanged sources, which srcversion (a hash of the sources)
+// cannot. Comparing only what both sides have is what keeps a record written before koId
+// existed comparable with one written now - demanding equality of all three fields would read
+// every stored record as "changed" the first time this runs.
+// koId is only compared against an id of the same type: it falls back to srcversion or sha256
+// when a module carries no build-id note, so two records can hold ids of different types, and
+// "srcversion:ABC" vs "buildid:XYZ" says nothing about whether the module changed (mirrors how
+// "same" picks a common id type in scripts/tls_module_id.sh).
+function isSameIdentity(a, b) {
+  const fa = identityFields(a);
+  const fb = identityFields(b);
+  if (!fa || !fb) return false;
+  if (fa.koId && fb.koId && idType(fa.koId) === idType(fb.koId))
+    return fa.koId === fb.koId;
+  for (const field of ['srcversion', 'version']) {
+    if (fa[field] && fb[field]) return fa[field] === fb[field];
+  }
+  return false; // nothing comparable in common, so no evidence that they are the same module
 }
 
 // mtime (in seconds) of the current xt_udp_tls module file. Used to tell whether a
@@ -119,11 +178,20 @@ async function getModuleVersion(modName, koPath) {
 // with a fresh mtime, so a crash older than the .ko belongs to a previous (already
 // replaced) module version and must not disable the current one. Returns null when
 // the mtime cannot be determined (e.g. koPath does not exist).
+// The bundled .ko is often a symlink (e.g. gse's xt_udp_tls.ko.aarch64-none-linux-gnu-gcc
+// -> xt_udp_tls.ko.<checksum>), and `stat` reports the symlink's own mtime, not the
+// module's. Take the newer of the two: replacing the module content refreshes the target,
+// re-pointing the symlink at another build refreshes the link itself.
 async function getModuleFileMtimeSec(koPath) {
-  const r = await execFile('stat', ['-c', '%Y', koPath]).catch(() => null);
-  if (!r) return null;
-  const sec = parseInt(r.stdout.trim(), 10);
-  return Number.isFinite(sec) ? sec : null;
+  if (!koPath) return null;
+  const results = await Promise.all([
+    execFile('stat', ['-L', '-c', '%Y', koPath]).catch(() => null), // dereferenced (the real .ko)
+    execFile('stat', ['-c', '%Y', koPath]).catch(() => null),       // koPath itself, symlink or not
+  ]);
+  const secs = results
+    .map((r) => r && parseInt(r.stdout.trim(), 10))
+    .filter((sec) => Number.isFinite(sec));
+  return secs.length ? Math.max(...secs) : null;
 }
 
 async function readCrashInfo() {
@@ -208,9 +276,15 @@ async function checkPstoreAndUpdateRedis(modName, koPath) {
     // only treat the version as "known different" when we could actually read the
     // current module's version; koPath may not exist yet (see comment above), and an
     // unknown version must not be confused with a confirmed version change.
-    const isVersionKnownDifferent = !!(currentVersion && storedVersion &&
-      (currentVersion.version !== storedVersion.version ||
-       currentVersion.srcversion !== storedVersion.srcversion));
+    // A missing stored record, or one with no usable identity (written before the ko-hash
+    // fallback existed, on a build whose modinfo prints no version), cannot be compared
+    // against. Treat that as changed once we can identify the current module, otherwise
+    // such a box stays disabled forever: nothing else ever records an identity for it,
+    // because recording only happens on a successful load and loading is what is disabled.
+    // If the module really is still broken it crashes again, and by then the identity is
+    // recorded and the disable sticks.
+    const isVersionKnownDifferent = !!(currentVersion &&
+      (!hasIdentity(storedVersion) || !isSameIdentity(currentVersion, storedVersion)));
 
     if (crashInfo.shouldDisableUdpTls) {
       if (isVersionKnownDifferent) {
@@ -276,7 +350,7 @@ async function checkPstoreAndUpdateRedis(modName, koPath) {
 
             crashInfo.shouldDisableUdpTls = true;
             crashInfo.udpTlsDisabledOn = Math.round(Date.now() / 1000);
-            const versionInfo = currentVersion ? ` (module version ${currentVersion.version}/${currentVersion.srcversion})` : '';
+            const versionInfo = currentVersion ? ` (module version ${currentVersion.version}/${currentVersion.srcversion}/${currentVersion.koId})` : '';
             log.warn(`UDP TLS crash detected${versionInfo}, disabling UDP TLS`);
             updateCrashInfoNeed = true;
           } else {

--- a/platform/platform.sh
+++ b/platform/platform.sh
@@ -118,6 +118,27 @@ function get_tls_ko_path {
   echo $ko_path
 }
 
+# module identity helpers, see scripts/tls_module_id.sh. Builds without MODULE_VERSION and
+# without CONFIG_MODULE_SRCVERSION_ALL (orange's aarch64 6.6.104) expose no version at all,
+# neither in modinfo nor under /sys/module/<m>/, so identity comes from the GNU build-id
+# which both the loaded module and the .ko still carry.
+TLS_MODULE_ID_SCRIPT="$(dirname "$FW_PLATFORM_DIR")/scripts/tls_module_id.sh"
+
+# id of the bundled .ko, for recording which module was loaded (empty if undeterminable)
+function get_tls_ko_id {
+  "$TLS_MODULE_ID_SCRIPT" file "$1"
+}
+
+# id of the module currently loaded in the kernel (empty if undeterminable)
+function get_loaded_tls_module_id {
+  "$TLS_MODULE_ID_SCRIPT" loaded "$1"
+}
+
+# 0 the loaded module is the one built from this .ko, 1 it is not, 2 cannot tell
+function tls_module_matches_ko {
+  "$TLS_MODULE_ID_SCRIPT" same "$1" "$2"
+}
+
 case "$UNAME" in
   "x86_64")
     if [[ -e /etc/firewalla-release ]]; then
@@ -236,6 +257,37 @@ if [ "$branch" = "master" ]; then
 fi
 
 
+# bundled path of the iptables userspace extension of a tls module, empty if none is
+# available for this platform/distro. Kept in one place so the install and the
+# "does it need an update" check always look at the same file.
+function get_tls_so_path {
+  local module_name=$1 arch so_path so_path_alt
+  arch=$(uname -m)
+  so_path=${FW_PLATFORM_CUR_DIR}/files/shared_objects/$(lsb_release -cs)/lib${module_name}.so
+  so_path_alt="/media/root-ro/usr/lib/${arch}-linux-gnu/xtables/lib${module_name}.so"
+  if [[ -f $so_path ]]; then
+    echo "$so_path"
+  elif [[ -f $so_path_alt ]]; then
+    echo "$so_path_alt"
+  fi
+}
+
+function get_tls_so_installed_path {
+  echo "/usr/lib/$(uname -m)-linux-gnu/xtables/lib$1.so"
+}
+
+# install the userspace .so only. Unlike the kernel module this touches neither the
+# loaded module nor existing iptables rules, so it needs no rmmod/reload cycle.
+function installTLSSharedObject {
+  local module_name=$1 so_path
+  so_path=$(get_tls_so_path "${module_name}")
+  if [[ -z $so_path ]]; then
+    echo "Error: no lib${module_name}.so available for this platform"
+    return 1
+  fi
+  sudo install -D -v -m 644 "${so_path}" "$(dirname "$(get_tls_so_installed_path "${module_name}")")"
+}
+
 function installTLSModule() {
   uid=$(id -u pi)
   gid=$(id -g pi)
@@ -269,32 +321,31 @@ function installTLSModule() {
     else
       sudo modprobe ${module_name} max_host_sets=1024 hostset_uid=${uid} hostset_gid=${gid}
     fi
-    arch=$(uname -m)
-    so_path=${FW_PLATFORM_CUR_DIR}/files/shared_objects/$(lsb_release -cs)/lib${module_name}.so
-    so_path_alt="/media/root-ro/usr/lib/${arch}-linux-gnu/xtables/lib${module_name}.so"
-
-    if [[ -f $so_path ]]; then
-      sudo install -D -v -m 644 ${so_path} /usr/lib/${arch}-linux-gnu/xtables
-    elif [[ -f $so_path_alt ]]; then
-      sudo install -D -v -m 644 ${so_path_alt} /usr/lib/${arch}-linux-gnu/xtables
-    fi
+    installTLSSharedObject ${module_name}
 
   fi
   if [[ ${module_name} = "xt_udp_tls" ]] && lsmod | grep -wq "xt_udp_tls"; then
-    local ko_path version srcversion crash_info updated
+    local ko_path version srcversion ko_id described crash_info updated
     ko_path=$(get_tls_ko_path xt_udp_tls)
+    version=""; srcversion=""; ko_id=""
     if [[ -f "$ko_path" ]]; then
-      version=$(modinfo "$ko_path" 2>/dev/null | awk '/^version:/{print $2}')
-      srcversion=$(modinfo "$ko_path" 2>/dev/null | awk '/^srcversion:/{print $2}')
+      # read it from the module image rather than through modinfo: the bundled .ko may be
+      # compressed, and on gse it is xt_udp_tls.ko.<kernel checksum> (or a .ko.<compiler>
+      # symlink to it), a name modinfo refuses - which used to leave this record empty
+      described=$("$TLS_MODULE_ID_SCRIPT" describe "$ko_path")
+      version=$(awk -F= '/^version=/{print $2; exit}' <<< "$described")
+      srcversion=$(awk -F= '/^srcversion=/{print $2; exit}' <<< "$described")
+      ko_id=$(awk -F= '/^id=/{print $2; exit}' <<< "$described")
     else
+      # loaded by name, there is no bundled .ko to look at
       version=$(modinfo xt_udp_tls 2>/dev/null | awk '/^version:/{print $2}')
       srcversion=$(modinfo xt_udp_tls 2>/dev/null | awk '/^srcversion:/{print $2}')
     fi
     crash_info=$(redis-cli --raw get kernel_crash_info 2>/dev/null)
     [[ -z "$crash_info" ]] && crash_info='{}'
     updated=$(echo "$crash_info" | jq \
-      --arg v "$version" --arg sv "$srcversion" \
-      '.udpModuleVersion = {"version": $v, "srcversion": $sv} | .shouldDisableUdpTls = false' 2>/dev/null | jq -c )
+      --arg v "$version" --arg sv "$srcversion" --arg ki "$ko_id" \
+      '.udpModuleVersion = {"version": $v, "srcversion": $sv, "koId": $ki} | .shouldDisableUdpTls = false' 2>/dev/null | jq -c )
     [[ -n "$updated" ]] && redis-cli set kernel_crash_info "$updated" > /dev/null
   fi
   return

--- a/scripts/tls_module_id.sh
+++ b/scripts/tls_module_id.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+#
+# Identity of a TLS kernel module, used to tell whether the module currently loaded in the
+# kernel is the one built from the .ko we ship.
+#
+#   tls_module_id.sh loaded <module_name>       print the loaded module's id, or nothing
+#   tls_module_id.sh file   <ko_path>           print the bundled .ko's id, or nothing
+#   tls_module_id.sh same   <module_name> <ko_path>
+#                                               exit 0 same, 1 different, 2 cannot tell
+#   tls_module_id.sh describe <ko_path>         print what identifies the bundled .ko:
+#                                                 version=<v>      (if the module carries one)
+#                                                 srcversion=<sv>  (if the module carries one)
+#                                                 id=<type>:<hex>  (its strongest id)
+#
+# Ids are type-tagged ("srcversion:<hex>", "buildid:<hex>", "sha256:<hex>") and only ids of
+# the same type are comparable, hence "same" instead of a string compare by the caller.
+#
+# Newer kernels build these modules without MODULE_VERSION and without
+# CONFIG_MODULE_SRCVERSION_ALL - on orange's aarch64 6.6.104 neither modinfo nor
+# /sys/module/<m>/{version,srcversion} carries anything. What does survive on both sides is
+# the GNU build-id: the kernel exposes the loaded module's note in
+# /sys/module/<m>/notes/.note.gnu.build-id, and the same note sits in the .ko itself. Both
+# sides can therefore be identified without recording anything at load time.
+#
+# version and srcversion of a .ko come from modinfo(8), which needs the file name to end in a
+# module extension: gse ships its modules as xt_udp_tls.ko.<kernel checksum> with a
+# xt_udp_tls.ko.<compiler> symlink pointing at it, and modinfo refuses both names. Pointing a
+# temporary <module>.ko symlink at the file is enough to make modinfo read it (see ko_modinfo),
+# whatever the real name is and whether or not the module is compressed.
+# The build-id is not something modinfo reports, so that one is read out of the module image.
+#
+# Verified on gold 6.5/5.15, pse 5.15.78, gse 5.10.110, purple 4.9.241, orange 6.6.104 and
+# goldplus2 6.6.104: every one of them exposes notes/.note.gnu.build-id for loaded modules.
+#
+# sha256 of the whole file is the last resort. It is only ever compared against an id of the
+# same file taken at another time (KernelCrashMonitor's record of the module that was loaded
+# when a crash happened), never against the loaded module.
+
+mode=$1
+
+# a GNU build-id note is namesz=4 descsz=20 type=3 "GNU\0" followed by the 20-byte id.
+# Only sha1-sized (0x14) ids are recognized; anything else falls through to another id type.
+NOTE_PREFIX_HEX='040000001400000003000000474e5500'
+
+function hex_of {
+  od -An -v -tx1 | tr -d ' \n'
+}
+
+# ── loaded module ────────────────────────────────────────────────────────────
+# every id the kernel exposes for the loaded module, strongest first. build-id comes first
+# because it identifies the build, while srcversion only hashes the sources: the same sources
+# built with another toolchain or config keep their srcversion but are a different module.
+function loaded_ids {
+  local module_name=$1 hex
+  [[ -n $module_name ]] || return 1
+  local note_path="/sys/module/${module_name}/notes/.note.gnu.build-id"
+  if [[ -r $note_path ]]; then
+    hex=$(hex_of < "$note_path")
+    [[ $hex =~ ^${NOTE_PREFIX_HEX}([0-9a-f]{40})$ ]] && echo "buildid:${BASH_REMATCH[1]}"
+  fi
+  local srcversion_path="/sys/module/${module_name}/srcversion"
+  if [[ -r $srcversion_path ]]; then
+    read -r hex < "$srcversion_path"
+    [[ -n $hex ]] && echo "srcversion:${hex}"
+  fi
+}
+
+# ── bundled .ko ──────────────────────────────────────────────────────────────
+# the module image, decompressed if needed, on stdout
+function ko_image {
+  local ko_path=$1 magic
+  [[ -r $ko_path ]] || return 1
+  magic=$(od -An -N4 -v -tx1 < "$ko_path" | tr -d ' \n')
+  case $magic in
+    fd377a58) xz -dc -- "$ko_path" 2>/dev/null ;;   # XZ
+    28b52ffd) zstd -dc -- "$ko_path" 2>/dev/null ;; # zstd
+    1f8b*)    gzip -dc -- "$ko_path" 2>/dev/null ;; # gzip
+    *)        cat -- "$ko_path" ;;
+  esac
+}
+
+# On success IMAGE holds the decompressed module image. Fails when the file cannot be read,
+# when no decompressor handled it, or when the result does not look like a complete module:
+# vermagic= is present in every loadable module, and requiring it keeps a partially written
+# or truncated file from yielding an id. That matters because an id derived from a corrupt
+# file could differ from the loaded module and trigger a reload that then fails to insmod -
+# without an id the caller is told "cannot tell" and leaves the working module alone.
+IMAGE=""
+function ensure_image {
+  local ko_path=$1
+  [[ -n $IMAGE ]] && return 0
+  [[ -r $ko_path ]] || return 1
+  IMAGE=$(mktemp) || { IMAGE=""; return 1; }
+  trap 'rm -f "$IMAGE"' EXIT
+  ko_image "$ko_path" > "$IMAGE" 2>/dev/null || { rm -f "$IMAGE"; IMAGE=""; return 1; }
+  grep -a -q 'vermagic=' "$IMAGE" || { rm -f "$IMAGE"; IMAGE=""; return 1; }
+  return 0
+}
+
+# modinfo output for a .ko whatever its file name is: modinfo only accepts names ending in a
+# module extension, so files like xt_udp_tls.ko.<kernel checksum> (and the .ko.<compiler>
+# symlink gse points at it) get a temporary <module>.ko symlink to read through. modinfo
+# handles the compressed ones itself.
+function ko_modinfo {
+  local ko_path=$1
+  [[ -r $ko_path ]] || return 1
+  [[ $ko_path == *.ko ]] && { modinfo "$ko_path" 2>/dev/null; return; }
+  local dir link rc
+  dir=$(mktemp -d) || return 1
+  link="${dir}/$(basename "${ko_path%%.ko*}").ko"
+  ln -s "$(readlink -f "$ko_path")" "$link" || { rm -rf "$dir"; return 1; }
+  modinfo "$link" 2>/dev/null
+  rc=$?
+  rm -rf "$dir"
+  return $rc
+}
+
+# On success MODINFO holds modinfo's output for the .ko. Fails when modinfo cannot parse the
+# file at all, which - like the vermagic check above - is how a corrupt file is told apart from
+# a module: every module modinfo can read reports a vermagic.
+MODINFO=""
+MODINFO_TRIED=0
+function ensure_modinfo {
+  [[ $MODINFO_TRIED -eq 1 ]] && { [[ -n $MODINFO ]]; return; }
+  MODINFO_TRIED=1
+  MODINFO=$(ko_modinfo "$1")
+  grep -q '^vermagic:' <<< "$MODINFO" || MODINFO=""
+  [[ -n $MODINFO ]]
+}
+
+# every id the bundled .ko yields, strongest first, in the same order as loaded_ids
+function file_ids {
+  local ko_path=$1 hex is_module=0
+  [[ -r $ko_path ]] || return 1
+  if ensure_image "$ko_path"; then
+    is_module=1
+    hex=$(hex_of < "$IMAGE")
+    [[ $hex =~ ${NOTE_PREFIX_HEX}([0-9a-f]{40}) ]] && echo "buildid:${BASH_REMATCH[1]}"
+  fi
+  if ensure_modinfo "$ko_path"; then
+    is_module=1
+    hex=$(awk '/^srcversion:/{print $2; exit}' <<< "$MODINFO")
+    [[ -n $hex ]] && echo "srcversion:${hex}"
+  fi
+  # Hashing the raw file is the last resort, and only for a file that proved to be a module:
+  # neither the image nor modinfo vouching for it means it is corrupt or truncated, and a hash
+  # of that would still look like a perfectly good identity - one that differs from the stored
+  # one, which is enough for KernelCrashMonitor to clear a crash-safety disable. With no id at
+  # all the caller is told "unknown" instead and leaves that decision untouched.
+  [[ $is_module -eq 1 ]] || return 1
+  hex=$(sha256sum "$ko_path" 2>/dev/null | awk '{print $1}')
+  [[ -n $hex ]] && echo "sha256:${hex}"
+}
+
+# id_of_type <type> <id>... : the id of that type among the given ones, empty if absent
+function id_of_type {
+  local id_type=$1; shift
+  local id
+  for id in "$@"; do
+    [[ $id == "${id_type}:"* ]] && { echo "$id"; return 0; }
+  done
+  return 1
+}
+
+case "$mode" in
+  loaded)
+    loaded_ids "$2" | sed -n 1p
+    ;;
+  file)
+    file_ids "$2" | sed -n 1p
+    ;;
+  describe)
+    # prepared up front so the file_ids call below reuses both instead of decompressing the
+    # module and running modinfo a second time
+    ensure_image "$2"
+    if ensure_modinfo "$2"; then
+      value=$(awk '/^version:/{print $2; exit}' <<< "$MODINFO")
+      [[ -n $value ]] && echo "version=${value}"
+      value=$(awk '/^srcversion:/{print $2; exit}' <<< "$MODINFO")
+      [[ -n $value ]] && echo "srcversion=${value}"
+    fi
+    id=$(file_ids "$2" | sed -n 1p)
+    [[ -n $id ]] || exit 1
+    echo "id=${id}"
+    ;;
+  same)
+    mapfile -t loaded < <(loaded_ids "$2")
+    mapfile -t file < <(file_ids "$3")
+    # compare on the strongest id type available on both sides. sha256 is deliberately not
+    # in this list: it cannot be derived from a loaded module, so a file that yields nothing
+    # but a hash (unreadable image, no build-id, no srcversion) is simply not comparable.
+    for id_type in buildid srcversion; do
+      lhs=$(id_of_type "$id_type" "${loaded[@]}")
+      rhs=$(id_of_type "$id_type" "${file[@]}")
+      [[ -n $lhs && -n $rhs ]] || continue
+      [[ $lhs == "$rhs" ]] && exit 0 || exit 1
+    done
+    exit 2
+    ;;
+  *)
+    echo "Usage: $0 loaded <module_name> | file <ko_path> | describe <ko_path> | same <module_name> <ko_path>" >&2
+    exit 2
+    ;;
+esac

--- a/test/test_KernelCrashMonitor.js
+++ b/test/test_KernelCrashMonitor.js
@@ -47,7 +47,12 @@ class FakeRedis {
 //
 // fixtures:
 //   modinfoOutput: string | null            -- stdout for `modinfo <arg>` (null => reject)
-//   koMtime: number | undefined             -- mtime (sec) returned for `stat -c %Y <koPath>`
+//   koDescribe: string | undefined          -- stdout for `tls_module_id.sh describe <koPath>`,
+//                                              e.g. "version=1.0\nsrcversion=abc\nid=buildid:x"
+//                                              (undefined => reject, i.e. the .ko yields nothing)
+//   koMtime: number | undefined             -- mtime (sec) of the .ko itself, for `stat -L -c %Y`
+//   koLinkMtime: number | undefined         -- mtime (sec) of the koPath symlink, for `stat -c %Y`
+//                                              (defaults to koMtime, i.e. koPath is a plain file)
 //   dmesgFindOutput: string                 -- stdout for the pstore `find ... -name dmesg-*` scan
 //   fileContents: { path: content }         -- backing content for grep/cat over dmesg files
 //   archiveDirs: string[]                   -- stdout lines for `ls -1 ARCHIVE_PATH`
@@ -64,9 +69,16 @@ function makeExecFile(fixtures) {
       if (fixtures.modinfoOutput == null) throw new Error('modinfo: command not found');
       return { stdout: fixtures.modinfoOutput };
     }
-    if (file === 'stat' && args[0] === '-c' && args[1] === '%Y') {
-      if (fixtures.koMtime === undefined) return { stdout: '' }; // unknown mtime => null
-      return { stdout: String(fixtures.koMtime) };
+    if (file.endsWith('/tls_module_id.sh')) {
+      if (fixtures.koDescribe === undefined) throw new Error(`tls_module_id.sh: nothing for ${args[1]}`);
+      return { stdout: `${fixtures.koDescribe}\n` };
+    }
+    if (file === 'stat' && args.includes('%Y')) {
+      // `stat -L` dereferences the symlink (the real .ko), plain `stat` reports koPath itself
+      const mtime = args.includes('-L') ? fixtures.koMtime
+        : (fixtures.koLinkMtime !== undefined ? fixtures.koLinkMtime : fixtures.koMtime);
+      if (mtime === undefined) return { stdout: '' }; // unknown mtime => null
+      return { stdout: String(mtime) };
     }
     if (file === 'sudo' && args[0] === 'find' && args.includes('-name')) {
       return { stdout: fixtures.dmesgFindOutput || '' };
@@ -100,6 +112,7 @@ function loadKCM(fakeRedis, execFileImpl) {
       warn: (...a) => logs.warn.push(a.join(' ')),
       error: (...a) => logs.error.push(a.join(' ')),
     }),
+    './Firewalla.js': { getFirewallaHome: () => '/home/pi/firewalla', '@noCallThru': true },
     'child-process-promise': { execFile: execFileImpl, '@noCallThru': true },
   });
   mod._logs = logs;
@@ -108,6 +121,14 @@ function loadKCM(fakeRedis, execFileImpl) {
 
 function modinfoStdout(version, srcversion) {
   return `filename:       /lib/modules/xt_udp_tls.ko\nversion:        ${version}\nsrcversion:     ${srcversion}\ndepends:        \n`;
+}
+
+// modinfo output on builds without MODULE_VERSION / CONFIG_MODULE_SRCVERSION_ALL
+// (e.g. the aarch64 6.6.104 kernel on orange): neither version: nor srcversion:
+function modinfoStdoutNoVersion() {
+  return 'filename:       /home/pi/firewalla/platform/orange/files/kernel_modules/6.6.104/xt_udp_tls.ko\n' +
+    'alias:          ipt_tls\nlicense:        GPL\ndepends:        x_tables\nname:           xt_udp_tls\n' +
+    'vermagic:       6.6.104 SMP mod_unload aarch64\nparm:           max_host_sets:int\n';
 }
 
 describe('KernelCrashMonitor', function () {
@@ -165,7 +186,9 @@ describe('KernelCrashMonitor', function () {
     });
 
     it('returns false once onUdpTlsModuleLoaded clears the cache', async function () {
-      fakeRedis.seed({ shouldDisableUdpTls: true });
+      // stored identity matches the modinfo output below, so the disable stays in effect
+      // through checkPstoreAndUpdateRedis and only onUdpTlsModuleLoaded clears it
+      fakeRedis.seed({ shouldDisableUdpTls: true, udpModuleVersion: { version: '1.0', srcversion: 'abc', koId: '' } });
       const { execFile } = makeExecFile({ dmesgFindOutput: '', modinfoOutput: modinfoStdout('1.0', 'abc') });
       const kcm = loadKCM(fakeRedis, execFile);
 
@@ -188,8 +211,49 @@ describe('KernelCrashMonitor', function () {
       await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
       const info = await kcm.getCrashInfo();
-      expect(info.udpModuleVersion).to.deep.equal({ version: '1.0', srcversion: 'abc123' });
+      expect(info.udpModuleVersion).to.deep.equal({ version: '1.0', srcversion: 'abc123', koId: '' });
       expect(info.shouldDisableUdpTls).to.be.false;
+    });
+
+    it('records the ko id as identity when the .ko carries no version/srcversion', async function () {
+      const { execFile, execLog } = makeExecFile({
+        modinfoOutput: modinfoStdoutNoVersion(),
+        koDescribe: 'id=buildid:deadbeef',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect(execLog).to.include('/home/pi/firewalla/scripts/tls_module_id.sh describe /lib/modules/xt_udp_tls.ko');
+      const info = await kcm.getCrashInfo();
+      expect(info.udpModuleVersion).to.deep.equal({ version: '', srcversion: '', koId: 'buildid:deadbeef' });
+    });
+
+    it('does not record any version when neither the .ko nor modinfo yields one', async function () {
+      fakeRedis.seed({ udpModuleVersion: { version: '', srcversion: '', koId: 'buildid:oldhash' } });
+      const { execFile } = makeExecFile({ modinfoOutput: modinfoStdoutNoVersion() }); // koDescribe undefined => the .ko yields nothing
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      const info = await kcm.getCrashInfo();
+      expect(info.udpModuleVersion).to.deep.equal({ version: '', srcversion: '', koId: 'buildid:oldhash' });
+      expect(info.shouldDisableUdpTls).to.be.false;
+    });
+
+    it('records version, srcversion and the build id together when the .ko carries all three', async function () {
+      // gse: modinfo refuses xt_udp_tls.ko.<checksum>/.ko.<compiler>, so all three fields come
+      // out of the module image instead
+      const { execFile } = makeExecFile({
+        koDescribe: 'version=0.0.9\nsrcversion=24D95927CCDD39D26C85F3B\nid=buildid:7125e6c7',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko.aarch64-none-linux-gnu-gcc');
+
+      expect((await kcm.getCrashInfo()).udpModuleVersion).to.deep.equal({
+        version: '0.0.9', srcversion: '24D95927CCDD39D26C85F3B', koId: 'buildid:7125e6c7',
+      });
     });
 
     it('defaults to the module name "xt_udp_tls" when no path is given', async function () {
@@ -201,20 +265,20 @@ describe('KernelCrashMonitor', function () {
       expect(execLog.some(c => c === 'modinfo xt_udp_tls')).to.be.true;
     });
 
-    it('falls back to `modinfo <modName>` when modinfo on the koPath fails', async function () {
+    it('falls back to `modinfo <modName>` when the .ko cannot be described', async function () {
+      // koPath does not exist yet (or yields nothing): ask modinfo about the loaded module
       const { execFile, execLog } = makeExecFile({
-        modinfoOutput: modinfoStdout('3.0', 'xyz789'),
-        failOn: (cmd) => cmd === 'modinfo /lib/modules/xt_udp_tls.ko',
+        modinfoOutput: modinfoStdout('3.0', 'xyz789'), // koDescribe undefined => script fails
       });
       const kcm = loadKCM(fakeRedis, execFile);
 
       await kcm.onUdpTlsModuleLoaded('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
 
-      // tried the koPath first, then fell back to the module name
-      expect(execLog).to.include('modinfo /lib/modules/xt_udp_tls.ko');
+      // tried the .ko first, then fell back to the module name
+      expect(execLog).to.include('/home/pi/firewalla/scripts/tls_module_id.sh describe /lib/modules/xt_udp_tls.ko');
       expect(execLog).to.include('modinfo xt_udp_tls');
       const info = await kcm.getCrashInfo();
-      expect(info.udpModuleVersion).to.deep.equal({ version: '3.0', srcversion: 'xyz789' });
+      expect(info.udpModuleVersion).to.deep.equal({ version: '3.0', srcversion: 'xyz789', koId: '' });
     });
 
     it('still clears shouldDisableUdpTls when modinfo fails, without clobbering stored version', async function () {
@@ -352,6 +416,50 @@ describe('KernelCrashMonitor', function () {
       expect(info.lastCrashTS).to.equal(700);
     });
 
+    it('does NOT disable when koPath is a symlink that was re-pointed after the crash', async function () {
+      // gse ships xt_udp_tls.ko.aarch64-none-linux-gnu-gcc -> xt_udp_tls.ko.<checksum>: the
+      // target keeps its old mtime while the symlink is refreshed, so only the newer of the
+      // two shows that the effective module changed after the crash.
+      const dmesgFindOutput = `700.0 ${PSTORE_PATH}/dmesg-a\n`;
+      const { execFile, execLog } = makeExecFile({
+        dmesgFindOutput,
+        modinfoOutput: modinfoStdout('2.0', 'new'),
+        koMtime: 300,      // target content is older than the crash
+        koLinkMtime: 900,  // but the symlink was re-pointed after it
+        fileContents: {
+          [`${PSTORE_PATH}/dmesg-a`]: 'Kernel panic - not syncing\nModules linked in: xt_udp_tls ext4',
+        },
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect(execLog).to.include('stat -L -c %Y /lib/modules/xt_udp_tls.ko');
+      const info = await kcm.getCrashInfo();
+      expect(info.shouldDisableUdpTls).to.not.equal(true);
+      expect(info.crashesCount).to.be.undefined;
+    });
+
+    it('DOES disable when both the symlink and its target predate the crash', async function () {
+      const dmesgFindOutput = `700.0 ${PSTORE_PATH}/dmesg-a\n`;
+      const { execFile } = makeExecFile({
+        dmesgFindOutput,
+        modinfoOutput: modinfoStdout('2.0', 'new'),
+        koMtime: 300,
+        koLinkMtime: 500,
+        fileContents: {
+          [`${PSTORE_PATH}/dmesg-a`]: 'Kernel panic - not syncing\nModules linked in: xt_udp_tls ext4',
+        },
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      const info = await kcm.getCrashInfo();
+      expect(info.shouldDisableUdpTls).to.be.true;
+      expect(info.lastCrashTS).to.equal(700);
+    });
+
     it('does not double-count a udp-tls crash that is not newer than the last recorded one', async function () {
       fakeRedis.seed({ lastCrashTS: 500, crashesCount: 1, shouldDisableUdpTls: true });
       const dmesgFindOutput = `500.0 ${PSTORE_PATH}/dmesg-a\n`;
@@ -441,6 +549,203 @@ describe('KernelCrashMonitor', function () {
 
       const info = await kcm.getCrashInfo();
       expect(info.shouldDisableUdpTls).to.be.true;
+    });
+
+    it('re-enables UDP TLS when the ko id changed on a build whose modinfo prints no version', async function () {
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '', srcversion: '', koId: 'buildid:oldhash' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        modinfoOutput: modinfoStdoutNoVersion(),
+        koDescribe: 'id=buildid:newhash',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      const info = await kcm.getCrashInfo();
+      expect(info.shouldDisableUdpTls).to.be.false;
+      expect(info.udpTlsDisabledOn).to.equal(0);
+    });
+
+    it('keeps UDP TLS disabled when the ko id is unchanged', async function () {
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '', srcversion: '', koId: 'buildid:samehash' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        modinfoOutput: modinfoStdoutNoVersion(),
+        koDescribe: 'id=buildid:samehash',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.true;
+    });
+
+    it('re-enables UDP TLS when the stored record carries no identity at all (pre-koId record)', async function () {
+      // a box disabled before the ko-hash fallback existed: modinfo printed nothing, so the
+      // stored version is all-empty and could never be compared -> UDP TLS stayed disabled forever
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '', srcversion: '' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        modinfoOutput: modinfoStdoutNoVersion(),
+        koDescribe: 'id=buildid:somehash',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      const info = await kcm.getCrashInfo();
+      expect(info.shouldDisableUdpTls).to.be.false;
+      expect(info.udpTlsDisabledOn).to.equal(0);
+    });
+
+    it('re-enables UDP TLS when no version was ever recorded (disabled before any successful load)', async function () {
+      // observed on an orange box: {"monitorStartedAt":...,"shouldDisableUdpTls":true} and no
+      // udpModuleVersion at all. Nothing would ever record one, since recording happens on a
+      // successful load and loading is exactly what the flag disables.
+      fakeRedis.seed({ monitorStartedAt: 1783710366, shouldDisableUdpTls: true });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        modinfoOutput: modinfoStdoutNoVersion(),
+        koDescribe: 'id=buildid:somehash',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.false;
+      expect(kcm.shouldDisableUdpTls()).to.be.false;
+    });
+
+    it('does not re-enable a crash disabled in this same run', async function () {
+      // the re-enable check runs against the state read from redis, so a brand new crash
+      // (which records no version) must not be undone by the missing-identity rule above
+      const dmesgFindOutput = `800.0 ${PSTORE_PATH}/dmesg-a\n`;
+      const { execFile } = makeExecFile({
+        dmesgFindOutput,
+        modinfoOutput: modinfoStdoutNoVersion(),
+        koDescribe: 'id=buildid:somehash',
+        koMtime: 500, // crash at 800 is newer than the module
+        fileContents: {
+          [`${PSTORE_PATH}/dmesg-a`]: 'Kernel panic - not syncing\nModules linked in: xt_udp_tls ext4',
+        },
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.true;
+      expect(kcm.shouldDisableUdpTls()).to.be.true;
+    });
+
+    it('keeps UDP TLS disabled when a record predating koId still matches on srcversion', async function () {
+      // adding koId must not make every stored record read as "changed": with no koId on the
+      // stored side the comparison falls back to the strongest field both records carry
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '0.0.9', srcversion: 'SAME' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        koDescribe: 'version=0.0.9\nsrcversion=SAME\nid=buildid:abc',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.true;
+    });
+
+    it('keeps UDP TLS disabled when the stored and current koId are of different types', async function () {
+      // a module without a build-id note falls back to srcversion (or sha256) for its koId, so
+      // records can hold ids of different types. "srcversion:SAME" vs "buildid:X" is not
+      // evidence of a change, and srcversion is what both records can actually be compared on.
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '0.0.9', srcversion: 'SAME', koId: 'srcversion:SAME' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        koDescribe: 'version=0.0.9\nsrcversion=SAME\nid=buildid:X',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.true;
+    });
+
+    it('re-enables UDP TLS when ids of different types come with a changed srcversion', async function () {
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '0.0.9', srcversion: 'OLD', koId: 'sha256:aaa' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        koDescribe: 'version=0.0.9\nsrcversion=NEW\nid=buildid:bbb',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.false;
+    });
+
+    it('re-enables UDP TLS when only the build id changed (same sources, rebuilt module)', async function () {
+      // srcversion hashes the sources, so a rebuild with another toolchain keeps it; the build
+      // id is what shows the module actually changed
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '0.0.9', srcversion: 'SAME', koId: 'buildid:old' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        koDescribe: 'version=0.0.9\nsrcversion=SAME\nid=buildid:new',
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      const info = await kcm.getCrashInfo();
+      expect(info.shouldDisableUdpTls).to.be.false;
+      expect(info.udpTlsDisabledOn).to.equal(0);
+    });
+
+    it('keeps UDP TLS disabled when the .ko yields no identity at all (corrupt or truncated)', async function () {
+      // tls_module_id.sh hands out no id for a file that is not a readable module, so a corrupt
+      // .ko must not look like a new module version and clear the crash-safety disable
+      fakeRedis.seed({
+        shouldDisableUdpTls: true,
+        udpTlsDisabledOn: 111,
+        udpModuleVersion: { version: '0.0.9', srcversion: 'ABC', koId: 'buildid:X' },
+      });
+      const { execFile } = makeExecFile({
+        dmesgFindOutput: '',
+        modinfoOutput: null,   // not installed under /lib/modules either
+        // koDescribe undefined => the script exits non-zero with no id
+      });
+      const kcm = loadKCM(fakeRedis, execFile);
+
+      await kcm.checkPstoreAndUpdateRedis('xt_udp_tls', '/lib/modules/xt_udp_tls.ko');
+
+      expect((await kcm.getCrashInfo()).shouldDisableUdpTls).to.be.true;
+      expect(kcm.shouldDisableUdpTls()).to.be.true;
     });
 
     it('keeps UDP TLS disabled when the current version cannot be determined (module not yet installed)', async function () {


### PR DESCRIPTION
problem is because of MODULE_VERSION was removed from the new kernel, fix is use the buildid instead.