### PR TITLE
category: fix stale target-list hashset polling

### DIFF
--- a/alarm/ExceptionManager.js
+++ b/alarm/ExceptionManager.js
@@ -35,6 +35,8 @@ const exceptionPrefix = "exception:";
 const _ = require('lodash');
 const Alarm = require('../alarm/Alarm.js');
 const CategoryMatcher = require('./CategoryMatcher');
+const CategoryUpdater = require('../control/CategoryUpdater.js');
+const categoryUpdater = new CategoryUpdater();
 
 const sem = require('../sensor/SensorEventManager').getInstance();
 const firewalla = require('../net2/Firewalla');
@@ -109,6 +111,23 @@ module.exports = class {
       }
       this.categoryMap = newCategoryMap;
     }
+  }
+
+  // whether any persisted exception still references this category
+  async hasException(category) {
+    if (!category) return false;
+    const exceptions = await this.loadExceptionsAsync();
+    return exceptions.some(e => e.getCategory() === category);
+  }
+
+  // user target list categories are only kept alive by rules/exceptions referencing them;
+  // once the last exception referencing one is removed, stop polling its hashset if no rule
+  // is using it either, instead of leaving it active until the next reboot
+  async _maybeDeactivateCategory(category) {
+    if (!category || !categoryUpdater.isUserTargetList(category)) return;
+    if (categoryUpdater.hasActivePolicies(category)) return;
+    if (await this.hasException(category)) return;
+    await categoryUpdater.deactivateCategory(category);
   }
 
   getExceptionKey(exceptionID) {
@@ -358,14 +377,27 @@ module.exports = class {
 
     // unignore is set for backward compatibility, it's actually should be called "unallow"
     Bone.submitIntelFeedback('unignore', exception);
+
+    if (exception && exception['p.category.id']) {
+      await this._maybeDeactivateCategory(exception['p.category.id']);
+    }
   }
 
   async deleteExceptions(idList) {
     if (!idList) throw new Error("deleteException: null argument");
 
     if (idList.length) {
+      const multi = rclient.multi();
+      idList.forEach(id => multi.hgetall(exceptionPrefix + id));
+      const exceptions = await multi.execAsync();
+      const categories = _.uniq(exceptions.filter(Boolean).map(e => e['p.category.id']).filter(Boolean));
+
       await rclient.unlinkAsync(idList.map(id => exceptionPrefix + id));
       await rclient.sremAsync(exceptionQueue, idList);
+
+      for (const category of categories) {
+        await this._maybeDeactivateCategory(category);
+      }
     }
   }
 

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -65,6 +65,8 @@ const domainBlock = require('../control/DomainBlock.js');
 
 const CategoryUpdater = require('../control/CategoryUpdater.js')
 const categoryUpdater = new CategoryUpdater()
+const ExceptionManager = require('./ExceptionManager.js')
+const exceptionManager = new ExceptionManager()
 const CountryUpdater = require('../control/CountryUpdater.js')
 const countryUpdater = new CountryUpdater()
 const fc = require('../net2/config.js')
@@ -2656,6 +2658,14 @@ class PolicyManager2 {
 
         for (const target of targets) {
           await categoryUpdater.updateCategoryState(target, devOpts, pid, policy.dnsmasq_only, isBlockOrdisturb, false);
+          // user target list categories are activated on demand and never deactivated by the
+          // built-in category refresh logic; once the last rule referencing one is removed,
+          // stop polling its hashset instead of leaving it active until the next reboot
+          if (categoryUpdater.isUserTargetList(target) &&
+            !categoryUpdater.hasActivePolicies(target) &&
+            !(await exceptionManager.hasException(target))) {
+            await categoryUpdater.deactivateCategory(target);
+          }
         }
 
         if (["allow", "block", "route"].includes(action)) {

--- a/control/CategoryUpdater.js
+++ b/control/CategoryUpdater.js
@@ -405,6 +405,13 @@ class CategoryUpdater extends CategoryUpdaterBase {
     }
   }
 
+  // whether any active policy rule still references this category
+  hasActivePolicies(category) {
+    const categoryPolicies = this.activeCategoryPolicyMap.get(category);
+    if (!categoryPolicies) return false;
+    return categoryPolicies.numDefaultPolicies > 0 || categoryPolicies.numDomainOnlyPolicies > 0;
+  }
+
   updateDevCategoryMapping(category, devOpts, isBlock=true, isAdd = true) {
     if (!category || !devOpts) return;
     const { tags, intfs, scope, guids } = devOpts;

--- a/sensor/CategoryUpdateSensor.js
+++ b/sensor/CategoryUpdateSensor.js
@@ -62,6 +62,13 @@ const securityHashMapping = {
 
 const CATEGORY_DATA_KEY = "intel_proxy.data";
 const Constants = require('../net2/Constants.js');
+
+// fallbacks in case a sensor config override omits one of these fields;
+// setInterval() clamps a NaN delay to 1ms instead of erroring out
+const DEFAULT_REGULAR_INTERVAL = 28800;
+const DEFAULT_SECURITY_INTERVAL = 14400;
+const DEFAULT_COUNTRY_INTERVAL = 86400;
+
 class CategoryUpdateSensor extends Sensor {
   constructor(config) {
     super(config)
@@ -633,11 +640,11 @@ class CategoryUpdateSensor extends Sensor {
       await this.securityJob()
       await this.renewCountryList()
 
-      setInterval(this.regularJob.bind(this), this.config.regularInterval * 1000)
+      setInterval(this.regularJob.bind(this), (this.config.regularInterval || DEFAULT_REGULAR_INTERVAL) * 1000)
 
-      setInterval(this.securityJob.bind(this), this.config.securityInterval * 1000)
+      setInterval(this.securityJob.bind(this), (this.config.securityInterval || DEFAULT_SECURITY_INTERVAL) * 1000)
 
-      setInterval(this.countryJob.bind(this), this.config.countryInterval * 1000)
+      setInterval(this.countryJob.bind(this), (this.config.countryInterval || DEFAULT_COUNTRY_INTERVAL) * 1000)
 
       sem.emitLocalEvent({
         type: "CategoryUpdateSensorReady",

--- a/sensor/Guardian.js
+++ b/sensor/Guardian.js
@@ -38,6 +38,8 @@ const rp = require('request-promise');
 const PolicyManager2 = require('../alarm/PolicyManager2.js');
 const LiveTransport = require('./LiveTransport.js');
 const pm2 = new PolicyManager2();
+const ExceptionManager = require('../alarm/ExceptionManager.js');
+const exceptionManager = new ExceptionManager();
 
 const FireRouter = require('../net2/FireRouter');
 const _ = require('lodash');
@@ -513,6 +515,17 @@ module.exports = class {
     return false
   }
 
+  // same staleness caveat as isMspRelatedRule above: mspData.targetlists may be stale if the
+  // box was offline when the msp-side target list/membership changed
+  async isMspRelatedException(exception, { mspData }) {
+    if (mspData && mspData.targetlists) {
+      if (_.find(mspData.targetlists, { id: exception['p.category.id'] })) { // if it references an msp target list
+        return true;
+      }
+    }
+    return false
+  }
+
   async reset() {
     log.warn("Reset guardian settings", this.name);
     const mspId = await this.getMspId();
@@ -527,6 +540,18 @@ module.exports = class {
           await pm2.disableAndDeletePolicy(p.pid);
         }
       }))
+
+      // remove all msp related exceptions, e.g. exceptions muting alarms on an msp target list;
+      // these are not tied to any rule's lifecycle and would otherwise keep the target list's
+      // category activated (and its hashset polled) forever
+      const exceptions = await exceptionManager.loadExceptionsAsync();
+      const mspRelatedEids = (await Promise.all(exceptions.map(async e =>
+        await this.isMspRelatedException(e, { mspData }) ? e.eid : null
+      ))).filter(eid => eid);
+      if (mspRelatedEids.length) {
+        log.info("Remove msp exceptions", mspRelatedEids);
+        await exceptionManager.deleteExceptions(mspRelatedEids);
+      }
 
       // reset no_auto_upgrade flags
       await upgradeManager.setAutoUpgradeState()


### PR DESCRIPTION
Fixes firewalla/firecommit#9107

Boxes were requesting MSP target-list hashsets (`app.TL-<uuid>`) that fishbone no longer authorized them for, forever — logged server-side as `Unauthorized hashset request`, growing daily across 78+ boxes.

## Root cause

Once a `TL-<uuid>` category is activated (via a rule or an exception muting alarms on it), nothing ever deactivates it:
- Deleting the rule/exception that referenced it never called `deactivateCategory()`, so `CategoryUpdateSensor` kept polling its hashset every 8h regardless.
- `Guardian.reset()` (on MSP unbind) cleaned up rules but never cleaned up exceptions, so a lingering exception alone could keep the target list active permanently, surviving any number of reboots.

## Fix

- `PolicyManager2`/`ExceptionManager`: when the last rule or exception referencing a user target list is removed, deactivate the category immediately instead of leaving it active until the next reboot.
- `Guardian.reset()`: also delete exceptions referencing an MSP target list on unbind, not just rules.
- `CategoryUpdateSensor`: fall back to the default poll interval if the config is missing/invalid, instead of `setInterval` silently clamping a `NaN` delay to 1ms (found while testing the above with a shortened poll interval).

## Verification

see [comment](https://github.com/firewalla/firecommit/issues/9107#issuecomment-5202323078) on the issue for before/after redis + log evidence.
