### PR TITLE
fix bug, syncNtpOffSet not work correctly

### DIFF
--- a/sensor/NTPRedirectPlugin.js
+++ b/sensor/NTPRedirectPlugin.js
@@ -186,12 +186,13 @@ class NTPRedirectPlugin extends MonitorablePolicyPlugin {
     if (now - this.lastNtpOffSetUpdateTime < this.ntpOffSetUpdateInterval)
       return;
 
-    const ntpOffSetEntries = await rclient.zrangeAsync(Constant.REDIS_KEY_NTP_OFF_SET, 0, -1).catch((err) => {
-      log.error(`Failed to load NTP off set from redis`, err);
-      return [];
-    });
-    if (ntpOffSetEntries.length === 0)
+    let ntpOffSetEntries;
+    try {
+      ntpOffSetEntries = await rclient.zrangeAsync(Constant.REDIS_KEY_NTP_OFF_SET, 0, -1);
+    } catch (err) {
+      log.error(`Failed to load NTP off set from redis, skip this sync and keep existing state`, err);
       return;
+    }
 
     this.ntpOffSet.clear();
     for (const devId of ntpOffSetEntries) {


### PR DESCRIPTION
when all records in ntp_off_set are expired syncNtpOffSet might exit early and resulting in the ipset not being refreshed.