### PR TITLE
release-on-merge: use static release notes instead of generate-notes

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -91,7 +91,7 @@ jobs:
               n=$((10#$n)); [ "$n" -gt "$max" ] && max=$n
             done
             TAG="${PREFIX}.$(printf '%03d' $((max + 1)))"
-            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --generate-notes; then
+            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --notes "Automated release for $BRANCH at $TARGET"; then
               echo "Created release $TAG"
               exit 0
             fi

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -43,6 +43,8 @@ jobs:
         env:
           BRANCH: ${{ github.event.pull_request.base.ref }}
           TARGET: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -91,7 +93,7 @@ jobs:
               n=$((10#$n)); [ "$n" -gt "$max" ] && max=$n
             done
             TAG="${PREFIX}.$(printf '%03d' $((max + 1)))"
-            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --notes "Automated release for $BRANCH at $TARGET"; then
+            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --notes "$PR_TITLE ($PR_URL, merged to $BRANCH at $TARGET)"; then
               echo "Created release $TAG"
               exit 0
             fi


### PR DESCRIPTION
## Summary

The release workflow failed on the first `goldplussfp-alpha` release ([run 32221648243](https://github.com/firewalla/firewalla/actions/runs/32221648243)): `gh release create --generate-notes` returned **HTTP 422 "body is too long (maximum is 125000 characters)"** on every attempt. With no previous release to anchor to, GitHub generated notes spanning the entire branch history. The retry loop misread the 422 as a tag-number race and consumed all five attempts (`-001` … `-005`) before giving up.

Replace `--generate-notes` with a short body built from the triggering PR: **"<PR title> (<PR url>, merged to <branch> at <sha>)"** — the PR title says what shipped, and the body can no longer exceed the API size limit. The title and URL are passed via `env` rather than interpolated into the script, since PR titles are untrusted input.

## Testing

Verified the failing run's logs show the identical 422 on all five attempts (not a tag race). The notes body is a one-liner, well under the 125k API limit.