### PR TITLE
Cherry-pick #9472 and #9473 to beta_23_0 (release workflow fixes)

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -91,7 +91,7 @@ jobs:
               n=$((10#$n)); [ "$n" -gt "$max" ] && max=$n
             done
             TAG="${PREFIX}.$(printf '%03d' $((max + 1)))"
-            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --generate-notes; then
+            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --notes "Automated release for $BRANCH at $TARGET"; then
               echo "Created release $TAG"
               exit 0
             fi

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -48,29 +48,29 @@ jobs:
           set -euo pipefail
 
           # actual branch -> "<model>-<channel>" (reverse of the model:template mapping;
-          # release_6_0=production, beta_6_0=beta, beta_7_0=alpha)
+          # release_6_0=prod, beta_6_0=beta, beta_7_0=alpha, matching getReleaseType())
           case "$BRANCH" in
-            release_7_0)  LABEL="gold-production" ;;
+            release_7_0)  LABEL="gold-prod" ;;
             beta_8_0)     LABEL="gold-beta" ;;
             beta_9_0)     LABEL="gold-alpha" ;;
-            release_9_0)  LABEL="purple-production" ;;
+            release_9_0)  LABEL="purple-prod" ;;
             beta_12_0)    LABEL="purple-beta" ;;
             beta_13_0)    LABEL="purple-alpha" ;;
-            release_10_0) LABEL="pse-production" ;;
+            release_10_0) LABEL="pse-prod" ;;
             beta_14_0)    LABEL="pse-beta" ;;
             beta_15_0)    LABEL="pse-alpha" ;;
-            release_11_0) LABEL="gse-production" ;;
+            release_11_0) LABEL="gse-prod" ;;
             beta_16_0)    LABEL="gse-beta" ;;
             beta_17_0)    LABEL="gse-alpha" ;;
-            release_12_0) LABEL="goldpro-production" ;;
+            release_12_0) LABEL="goldpro-prod" ;;
             beta_18_0)    LABEL="goldpro-beta" ;;
             beta_19_0)    LABEL="goldpro-alpha" ;;
-            release_13_0) LABEL="orange-production" ;;
+            release_13_0) LABEL="orange-prod" ;;
             beta_20_0)    LABEL="orange-beta" ;;
             beta_21_0)    LABEL="orange-alpha" ;;
-            release_14_0) LABEL="goldplussfp-production" ;;
-            beta_22_0)    LABEL="goldplussfp-beta" ;;
-            beta_23_0)    LABEL="goldplussfp-alpha" ;;            
+            release_14_0) LABEL="goldplus2-prod" ;;
+            beta_22_0)    LABEL="goldplus2-beta" ;;
+            beta_23_0)    LABEL="goldplus2-alpha" ;;
             *) echo "::error::no model/channel mapping for branch '$BRANCH'"; exit 1 ;;
           esac
 
@@ -78,16 +78,19 @@ jobs:
           [ -n "$VER" ] && [ "$VER" != null ] || { echo "::error::no .version in net2/config.json"; exit 1; }
           PREFIX="${LABEL}-v${VER}"
 
-          # patch auto-increments per (label, version); retry guards against tag races
+          # patch auto-increments per (label, version); retry guards against tag races.
+          # patch is dot-separated so the whole tag ends in a dotted version number
+          # ("<label>-v1.984.001"), which is what scripts/upgrade_verify.sh parses out
+          # of the tag name for the minimal version check
           for attempt in 1 2 3 4 5; do
             git fetch --tags --force --quiet
             max=0
-            for t in $(git tag -l "${PREFIX}-*"); do
-              n=${t#${PREFIX}-}
+            for t in $(git tag -l "${PREFIX}.*"); do
+              n=${t#${PREFIX}.}
               case "$n" in ''|*[!0-9]*) continue ;; esac
               n=$((10#$n)); [ "$n" -gt "$max" ] && max=$n
             done
-            TAG="${PREFIX}-$(printf '%03d' $((max + 1)))"
+            TAG="${PREFIX}.$(printf '%03d' $((max + 1)))"
             if gh release create "$TAG" --target "$TARGET" --title "$TAG" --generate-notes; then
               echo "Created release $TAG"
               exit 0

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -43,6 +43,8 @@ jobs:
         env:
           BRANCH: ${{ github.event.pull_request.base.ref }}
           TARGET: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -91,7 +93,7 @@ jobs:
               n=$((10#$n)); [ "$n" -gt "$max" ] && max=$n
             done
             TAG="${PREFIX}.$(printf '%03d' $((max + 1)))"
-            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --notes "Automated release for $BRANCH at $TARGET"; then
+            if gh release create "$TAG" --target "$TARGET" --title "$TAG" --notes "$PR_TITLE ($PR_URL, merged to $BRANCH at $TARGET)"; then
               echo "Created release $TAG"
               exit 0
             fi


### PR DESCRIPTION
Cherry-picks to fix the release-on-merge workflow on this branch:

- #9472 — correct tag name (dotted patch suffix so upgrade_verify.sh can parse the version)
- #9473 — replace `--generate-notes` with a short body built from the triggering PR title/URL, fixing the HTTP 422 "body is too long" failure from [run 32221648243](https://github.com/firewalla/firewalla/actions/runs/32221648243)

Resulting workflow file is byte-identical to current master.

Note: merging this PR will itself trigger the (old, still-broken) workflow from the base branch — expected to fail once more; subsequent merges will use the fixed copy.