### PR TITLE
Add MemorySwapMax to brofish.service so MemoryMax is enforceable

### DIFF
--- a/platform/blue/files/brofish.service
+++ b/platform/blue/files/brofish.service
@@ -14,6 +14,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=600M
+MemorySwapMax=64M
 
 [Install]
 WantedBy=multi-user.target

--- a/platform/gold/files/brofish.service
+++ b/platform/gold/files/brofish.service
@@ -15,6 +15,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=1000M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/goldplus2/files/brofish.service
+++ b/platform/goldplus2/files/brofish.service
@@ -13,6 +13,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=1000M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/goldpro/files/brofish.service
+++ b/platform/goldpro/files/brofish.service
@@ -15,6 +15,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=1000M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/gse/files/brofish.service
+++ b/platform/gse/files/brofish.service
@@ -13,6 +13,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=1000M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/navy/files/brofish.service
+++ b/platform/navy/files/brofish.service
@@ -15,6 +15,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=600M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/orange/files/brofish.service
+++ b/platform/orange/files/brofish.service
@@ -14,6 +14,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=600M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/pse/files/brofish.service
+++ b/platform/pse/files/brofish.service
@@ -13,6 +13,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=600M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/purple/files/brofish.service
+++ b/platform/purple/files/brofish.service
@@ -14,6 +14,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=600M
+MemorySwapMax=64M
 Nice=5
 
 [Install]

--- a/platform/red/files/brofish.service
+++ b/platform/red/files/brofish.service
@@ -14,6 +14,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=100M
+MemorySwapMax=64M
 
 [Install]
 WantedBy=multi-user.target

--- a/platform/ubt/files/brofish.service
+++ b/platform/ubt/files/brofish.service
@@ -14,6 +14,7 @@ RestartSec=10
 TimeoutStartSec=250
 TimeoutStopSec=8
 MemoryMax=600M
+MemorySwapMax=64M
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## What

Adds `MemorySwapMax=64M` directly after the existing `MemoryMax=` line in all
11 `platform/*/files/brofish.service` files (blue, gold, goldplus2, goldpro,
gse, navy, orange, pse, purple, red, ubt). One line per file; nothing else
changed.

## Why

`MemoryMax=` (cgroup v2 `memory.max`) alone does not actually bound a service
on a box that has swap: when the cgroup hits the cap, the kernel pushes its
anonymous pages to swap instead of OOM-killing inside the cgroup. The service
keeps growing "into" swap while staying nominally under its memory cap.

Observed failure sequence on a 4GB Gold in production:

1. A zeek worker leaked and reached the brofish `MemoryMax=1000M` cap.
2. Instead of a contained OOM kill, the cgroup started swapping heavily.
3. The resulting box-wide swap thrash starved everything else — dnsmasq
   became unresponsive on all networks (total DNS outage for every client)
   for roughly five minutes.
4. The outage ended only when the kernel's **global** OOM killer finally
   intervened.

`MemorySwapMax=64M` (cgroup v2 `memory.swap.max`) closes that escape hatch:
once the cgroup has used its small swap allowance, hitting `MemoryMax`
triggers an in-cgroup OOM kill of the zeek process. Zeek dies alone, the rest
of the box is unaffected, and the existing brofish watchdog restarts the
service cleanly — the recovery path already works perfectly once the kill is
contained; the only missing piece was making the kill happen inside the
cgroup.

## Tested

- Production Firewalla Gold Plus running 3.0929 (zeek 5.0.1).
- Deployed as a systemd drop-in with exactly these values
  (`MemoryMax=1000M` + `MemorySwapMax=64M`).
- Verified: on reaching the cap, zeek is OOM-killed inside the brofish
  cgroup, no box-wide impact, and the brofish watchdog restarts it cleanly.
- Other platforms are untested by the author; they carry the same
  `MemoryMax` mechanism, so the same swap-escape applies, but I have only
  validated the Gold Plus values.

## Scope / follow-up

This intentionally does **not** add `MemoryHigh=` (which would give earlier
kernel back-pressure before the hard cap) to keep the change minimal and easy
to review; that could be a follow-up if maintainers want it.

Fixes #9519

---

This change was developed with AI assistance (Claude) and was reviewed and
tested by the submitter.
