### PR TITLE
Bound WHOIS response buffering

### DIFF
--- a/lib/whois/index.js
+++ b/lib/whois/index.js
@@ -26,6 +26,7 @@ async function lookup (query, options) {
     let content = [];
     let contentSize = 0;
     let settled = false;
+    let rejectPromise;
 
     client.on('data', function(data){
         if (settled) {
@@ -51,8 +52,6 @@ async function lookup (query, options) {
         tryIP = true;
       }
     });
-
-    let rejectPromise;
 
     return new Promise((resolve, reject) => {
         rejectPromise = reject;

--- a/lib/whois/index.js
+++ b/lib/whois/index.js
@@ -10,6 +10,8 @@ const defaultOptions = {
   raw: false
 };
 
+const MAX_RESPONSE_SIZE = 1024 * 1024;
+
 async function lookup (query, options) {
   let tryIP = false;
 
@@ -22,8 +24,23 @@ async function lookup (query, options) {
     });
 
     let content = [];
+    let contentSize = 0;
+    let settled = false;
 
     client.on('data', function(data){
+        if (settled) {
+          return;
+        }
+
+        contentSize += data.length;
+        if (contentSize > MAX_RESPONSE_SIZE) {
+          const err = new Error(`WHOIS response exceeds maximum size of ${MAX_RESPONSE_SIZE} bytes`);
+          settled = true;
+          client.destroy();
+          rejectPromise(err);
+          return;
+        }
+
         content.push(data);
     });
 
@@ -35,8 +52,16 @@ async function lookup (query, options) {
       }
     });
 
+    let rejectPromise;
+
     return new Promise((resolve, reject) => {
+        rejectPromise = reject;
+
         client.on('close', function(err) {
+            if (settled) {
+              return;
+            }
+            settled = true;
             if (err) {
               if(tryIP) {
                 const optionsCopy = JSON.parse(JSON.stringify(options));

--- a/test/test_whois.js
+++ b/test/test_whois.js
@@ -26,6 +26,7 @@ describe('WHOIS response size limit', function () {
 
   let server;
   let port;
+  let connectionClosed;
 
   afterEach((done) => {
     if (server) {
@@ -39,6 +40,7 @@ describe('WHOIS response size limit', function () {
   function listen(response) {
     return new Promise((resolve, reject) => {
       server = net.createServer(socket => {
+        connectionClosed = new Promise(resolve => socket.once('close', resolve));
         socket.on('data', () => {});
         socket.end(response);
       });
@@ -67,10 +69,12 @@ describe('WHOIS response size limit', function () {
 
     expect(error).to.be.an('error');
     expect(error.message).to.equal('WHOIS response exceeds maximum size of 1048576 bytes');
+    await connectionClosed;
   });
 
   it('still accepts responses at or below the limit', async () => {
-    await listen('ok');
+    const response = 'x'.repeat(1024 * 1024);
+    await listen(response);
 
     const result = await whoisClient.lookup('example.com', {
       host: '127.0.0.1',
@@ -78,6 +82,6 @@ describe('WHOIS response size limit', function () {
       raw: true,
     });
 
-    expect(result).to.equal('ok');
+    expect(result).to.equal(response);
   });
 });

--- a/test/test_whois.js
+++ b/test/test_whois.js
@@ -40,7 +40,7 @@ describe('WHOIS response size limit', function () {
     return new Promise((resolve, reject) => {
       server = net.createServer(socket => {
         socket.on('data', () => {});
-        socket.write(response);
+        socket.end(response);
       });
 
       server.once('error', reject);

--- a/test/test_whois.js
+++ b/test/test_whois.js
@@ -36,11 +36,11 @@ describe('WHOIS response size limit', function () {
     }
   });
 
-  function listen() {
+  function listen(response) {
     return new Promise((resolve, reject) => {
       server = net.createServer(socket => {
         socket.on('data', () => {});
-        socket.write('x'.repeat(1024 * 1024 + 1));
+        socket.write(response);
       });
 
       server.once('error', reject);
@@ -52,7 +52,7 @@ describe('WHOIS response size limit', function () {
   }
 
   it('rejects and closes the connection when the response exceeds 1 MiB', async () => {
-    await listen();
+    await listen('x'.repeat(1024 * 1024 + 1));
 
     let error;
     try {
@@ -70,21 +70,7 @@ describe('WHOIS response size limit', function () {
   });
 
   it('still accepts responses at or below the limit', async () => {
-    await listen();
-    
-    server.close();
-    await new Promise((resolve, reject) => {
-      server.once('error', reject);
-      server.listen(0, '127.0.0.1', () => resolve());
-    });
-
-    const smallServer = server;
-    smallServer.removeAllListeners('connection');
-    smallServer.on('connection', socket => {
-      socket.write('ok');
-      socket.end();
-    });
-    port = smallServer.address().port;
+    await listen('ok');
 
     const result = await whoisClient.lookup('example.com', {
       host: '127.0.0.1',

--- a/test/test_whois.js
+++ b/test/test_whois.js
@@ -1,0 +1,97 @@
+/*    Copyright 2026 Firewalla Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+const net = require('net');
+const chai = require('chai');
+const expect = chai.expect;
+
+const whoisClient = require('../lib/whois');
+
+describe('WHOIS response size limit', function () {
+  this.timeout(5000);
+
+  let server;
+  let port;
+
+  afterEach((done) => {
+    if (server) {
+      server.close(done);
+      server = null;
+    } else {
+      done();
+    }
+  });
+
+  function listen() {
+    return new Promise((resolve, reject) => {
+      server = net.createServer(socket => {
+        socket.on('data', () => {});
+        socket.write('x'.repeat(1024 * 1024 + 1));
+      });
+
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        port = server.address().port;
+        resolve();
+      });
+    });
+  }
+
+  it('rejects and closes the connection when the response exceeds 1 MiB', async () => {
+    await listen();
+
+    let error;
+    try {
+      await whoisClient.lookup('example.com', {
+        host: '127.0.0.1',
+        port,
+        raw: true,
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).to.be.an('error');
+    expect(error.message).to.equal('WHOIS response exceeds maximum size of 1048576 bytes');
+  });
+
+  it('still accepts responses at or below the limit', async () => {
+    await listen();
+    
+    server.close();
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const smallServer = server;
+    smallServer.removeAllListeners('connection');
+    smallServer.on('connection', socket => {
+      socket.write('ok');
+      socket.end();
+    });
+    port = smallServer.address().port;
+
+    const result = await whoisClient.lookup('example.com', {
+      host: '127.0.0.1',
+      port,
+      raw: true,
+    });
+
+    expect(result).to.equal('ok');
+  });
+});


### PR DESCRIPTION
## Summary

The low-level WHOIS client buffers the entire remote response in memory by appending every received TCP chunk to an array and only concatenating the data after the connection closes.

A malicious or compromised WHOIS server can therefore send an arbitrarily large response and cause the Firewalla process to consume excessive memory.

## Changes

- Add a 1 MiB maximum WHOIS response size.
- Track the cumulative number of bytes received from the TCP connection.
- Reject the lookup when the response exceeds the configured maximum.
- Immediately destroy the socket when the limit is exceeded.
- Prevent the `close` handler from processing an already-rejected request.
- Preserve the existing WHOIS parsing and fallback behavior for valid responses.

## Security / Availability Impact

WHOIS responses are now explicitly bounded before additional buffering and parsing can continue.

This prevents the WHOIS client from retaining an unbounded amount of attacker-controlled network data in process memory and reduces the potential for memory-exhaustion-based denial of service through a malicious WHOIS endpoint.

## Testing

Added `test/test_whois.js` covering:

- rejection of responses larger than 1 MiB;
- normal handling of responses within the configured limit;
- the production TCP buffering path rather than a mocked socket implementation.

Full repository test execution was not performed in this environment.