### PR TITLE
fix: bound WHOIS referral processing and enforce lookup timeout

### DIFF
--- a/lib/whois/index.js
+++ b/lib/whois/index.js
@@ -12,59 +12,80 @@ const defaultOptions = {
 
 async function lookup (query, options) {
   let tryIP = false;
+  let timedOut = false;
+  let timeoutTimer = null;
 
-    if (options) {
-      options = Object.assign({}, defaultOptions, options);
+  if (options) {
+    options = Object.assign({}, defaultOptions, options);
+  } else {
+    options = Object.assign({}, defaultOptions);
+  }
+
+  let client = net.connect(options.port, options.host, function() {
+    client.write(query + '\n', 'ascii');
+  });
+
+  const content = [];
+
+  if (Number.isFinite(options.timeout) && options.timeout > 0) {
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      client.destroy(new Error('WHOIS lookup timed out'));
+    }, options.timeout);
+  }
+
+  client.on('data', function(data){
+    content.push(data);
+  });
+
+  client.on('error', (err) => {
+    log.error("Failed to lookup whois:", err);
+
+    if (!timedOut && err.code === 'ENOTFOUND' && options.ip) {
+      tryIP = true;
     }
-    
-    let client = net.connect(options.port, options.host, function() {
-        client.write(query + '\n', 'ascii'); 
-    });
+  });
 
-    let content = [];
+  return new Promise((resolve, reject) => {
+    client.on('close', function(err) {
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
 
-    client.on('data', function(data){
-        content.push(data);
-    });
+      if (timedOut) {
+        reject(new Error('WHOIS lookup timed out'));
+        return;
+      }
 
-    client.on('error', (err) => {
-      log.error("Failed to lookup whois:", err); // catch error to prevent node from crash
+      if (err) {
+        if(tryIP) {
+          const optionsCopy = JSON.parse(JSON.stringify(options));
+          optionsCopy.host = optionsCopy.ip;
+          delete optionsCopy.ip;
+          lookup(query, optionsCopy).then((result) => {
+            resolve(result);
+          }).catch((err) => {
+            reject(err);
+          });
+        } else {
+          reject(err);
+        }
+      } else {
+        let parser = './parser/' + options.host + '.js';
 
-      if(err.code === 'ENOTFOUND' && options.ip) {
-        tryIP = true;
+        let bc = Buffer.concat(content);
+
+        fs.exists(parser, function(exists) {
+          if (exists) {
+            resolve(options.raw ? bc.toString('ascii') : require(parser).parse(bc));
+          } else {
+            resolve(options.raw ? bc.toString('ascii') : {});
+          }
+        });
       }
     });
-
-    return new Promise((resolve, reject) => {
-        client.on('close', function(err) {
-            if (err) {
-              if(tryIP) {
-                const optionsCopy = JSON.parse(JSON.stringify(options));
-                optionsCopy.host = optionsCopy.ip;
-                delete optionsCopy.ip;
-                lookup(query, optionsCopy).then((result) => {
-                  resolve(result);
-                }).catch((err) => {
-                  reject(err);
-                });
-              } else {
-                reject(err);
-              }
-            } else {
-                let parser = './parser/' + options.host + '.js';
-
-                let bc = Buffer.concat(content);
-
-                fs.exists(parser, function(exists) {
-                    if (exists) {
-                        resolve(options.raw ? bc.toString('ascii') : require(parser).parse(bc));
-                    } else {
-                        resolve(options.raw ? bc.toString('ascii') : {});
-                    }
-                });
-            }
-        })
-    });
+  });
 }
 
 exports.lookup = lookup;

--- a/test/test_Whois.js
+++ b/test/test_Whois.js
@@ -28,7 +28,7 @@ describe('Whois referral handling', () => {
     Whois.timeout = 5000;
     const result = await Whois.lookup('example.com');
 
-    expect(result.refer).to.equal('whois3.example');
+    expect(result.refer).to.equal('whois4.example');
     expect(requests).to.deep.equal([
       'whois.iana.org',
       'whois1.example',

--- a/test/test_Whois.js
+++ b/test/test_Whois.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire').noPreserveCache();
+const EventEmitter = require('events');
+
+describe('Whois referral handling', () => {
+  it('limits referral depth instead of following an unbounded chain', async () => {
+    const requests = [];
+    const whoisClient = {
+      lookup: async (target, options) => {
+        requests.push(options.host);
+        const depth = requests.length - 1;
+        return depth < 5 ? `refer: whois${depth + 1}.example` : 'registrar: example';
+      }
+    };
+
+    const Whois = proxyquire('../util/Whois.js', {
+      '../lib/whois': whoisClient,
+      '../net2/logger.js': () => ({
+        info: () => {},
+        debug: () => {},
+        warn: () => {},
+        error: () => {}
+      })
+    });
+
+    Whois.timeout = 5000;
+    const result = await Whois.lookup('example.com');
+
+    expect(result.refer).to.equal('whois3.example');
+    expect(requests).to.deep.equal([
+      'whois.iana.org',
+      'whois1.example',
+      'whois2.example',
+      'whois3.example'
+    ]);
+  });
+
+  it('stops a referral cycle without issuing the repeated lookup', async () => {
+    const requests = [];
+    const whoisClient = {
+      lookup: async (target, options) => {
+        requests.push(options.host);
+        return options.host === 'whois.iana.org'
+          ? 'refer: whois.example'
+          : 'refer: whois.iana.org';
+      }
+    };
+
+    const Whois = proxyquire('../util/Whois.js', {
+      '../lib/whois': whoisClient,
+      '../net2/logger.js': () => ({
+        info: () => {},
+        debug: () => {},
+        warn: () => {},
+        error: () => {}
+      })
+    });
+
+    Whois.timeout = 5000;
+    const result = await Whois.lookup('example.com');
+
+    expect(result.refer).to.equal('whois.iana.org');
+    expect(requests).to.deep.equal([
+      'whois.iana.org',
+      'whois.example'
+    ]);
+  });
+
+  it('propagates a shrinking timeout budget to each referral lookup', async () => {
+    const timeouts = [];
+    const whoisClient = {
+      lookup: async (target, options) => {
+        timeouts.push(options.timeout);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        if (options.host === 'whois.iana.org')
+          return 'refer: whois.example';
+        return 'registrar: example';
+      }
+    };
+
+    const Whois = proxyquire('../util/Whois.js', {
+      '../lib/whois': whoisClient,
+      '../net2/logger.js': () => ({
+        info: () => {},
+        debug: () => {},
+        warn: () => {},
+        error: () => {}
+      })
+    });
+
+    Whois.timeout = 50;
+    const result = await Whois.lookup('example.com');
+
+    expect(result.registrar).to.equal('example');
+    expect(timeouts).to.have.length(2);
+    expect(timeouts[0]).to.be.within(1, 50);
+    expect(timeouts[1]).to.be.below(timeouts[0]);
+  });
+});
+
+describe('lib/whois timeout handling', () => {
+  it('destroys the socket and rejects when the lookup deadline expires', async () => {
+    class FakeSocket extends EventEmitter {
+      write() {}
+      destroy() {
+        this.destroyed = true;
+        process.nextTick(() => this.emit('close', true));
+      }
+    }
+
+    const socket = new FakeSocket();
+    const net = {
+      connect: (port, host, onConnect) => {
+        process.nextTick(onConnect);
+        return socket;
+      }
+    };
+
+    const whoisClient = proxyquire('../lib/whois/index.js', {
+      net,
+      fs: {
+        exists: () => {}
+      },
+      '../../net2/logger.js': () => ({
+        error: () => {}
+      })
+    });
+
+    let error;
+    try {
+      await whoisClient.lookup('example.com', {
+        host: 'whois.example',
+        timeout: 20,
+        raw: true
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(socket.destroyed).to.equal(true);
+    expect(error).to.exist;
+    expect(error.message).to.equal('WHOIS lookup timed out');
+  });
+});

--- a/util/Whois.js
+++ b/util/Whois.js
@@ -17,6 +17,8 @@ const nomatchSignals = [
   'returned 0 objects',
 ];
 
+const MAX_REFERRAL_DEPTH = 3;
+
 function _isValid(target) {
   return target && (isIP(target) || isFQDN(target));
 }
@@ -97,8 +99,24 @@ class Whois {
       return;
     }
 
-    async function _whois(_target, opts) {
-      let newOpts = Object.assign({}, opts, {raw: true});
+    const deadline = Date.now() + this.timeout;
+
+    async function _whois(_target, opts, depth, visited) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error("WHOIS lookup timed out");
+      }
+
+      const host = (opts.host || "").toLowerCase();
+      if (host && visited.has(host)) {
+        log.warn("WHOIS referral cycle detected at", host);
+        return {};
+      }
+      if (host) {
+        visited.add(host);
+      }
+
+      let newOpts = Object.assign({}, opts, {raw: true, timeout: remaining});
       log.debug("target: ", target, ", opts:", opts, ", newOpts:", newOpts);
 
       let info = await whoisClient.lookup(_target, newOpts);
@@ -114,24 +132,34 @@ class Whois {
 
       let refer = _info.refer;
       if (refer && isFQDN(refer)) {
-        _info = await _whois(_target, Object.assign({}, opts, {host: refer}));
+        if (depth >= MAX_REFERRAL_DEPTH) {
+          log.warn("WHOIS referral depth limit reached for", target);
+          return _info;
+        }
+
+        const referralHost = refer.toLowerCase();
+        if (visited.has(referralHost)) {
+          log.warn("WHOIS referral cycle detected at", referralHost);
+          return _info;
+        }
+
+        _info = await _whois(_target, Object.assign({}, opts, {host: refer}), depth + 1, visited);
       }
 
       return _info;
     }
 
-    let whois;
     try {
-      whois = await Promise.race([
-        new Promise(resolve => setTimeout(resolve, this.timeout)),
-        _whois(_target, {host: 'whois.iana.org', ip: "192.0.32.59", port: 43})
-      ]);
+      return await _whois(
+        _target,
+        {host: 'whois.iana.org', ip: "192.0.32.59", port: 43},
+        0,
+        new Set()
+      );
     } catch (err) {
       log.error(`Unable to lookup whois information for target: ${_target}, original target is: ${target}`, err);
       return;
     }
-
-    return whois;
   }
 }
 


### PR DESCRIPTION
## Summary

Prevent unbounded WHOIS referral traversal from escaping the existing lookup timeout.

The current WHOIS implementation uses a 5-second `Promise.race()` around the initial lookup, but that timeout only releases the caller. Recursive referral lookups can continue running after the timeout, potentially leaving network operations active and allowing unbounded referral chains or cycles.

## Changes

- Add a maximum WHOIS referral depth of 3.
- Track visited WHOIS hosts to prevent referral cycles.
- Replace the outer `Promise.race()` timeout with a single end-to-end lookup deadline.
- Propagate the remaining deadline to each recursive WHOIS lookup.
- Add timeout handling to the low-level WHOIS client.
- Destroy the active WHOIS TCP socket when the timeout expires.
- Preserve the existing IP fallback behavior for `ENOTFOUND`.
- Add regression tests for:
  - referral depth limiting;
  - referral cycle detection;
  - decreasing timeout budgets across referrals;
  - TCP socket destruction when the WHOIS deadline expires.

## Security / Reliability Impact

A malicious or compromised WHOIS server can no longer cause an unbounded referral chain to continue indefinitely.

The complete WHOIS operation is now bounded by the original 5-second deadline, and an expired lookup actively terminates the underlying TCP connection rather than merely abandoning the returned promise.

This reduces the potential for resource exhaustion from recursive WHOIS referrals and prevents timed-out lookup work from continuing in the background.

## Testing

Added `test/test_Whois.js` with coverage for the referral and timeout invariants described above.

GitHub Actions results are not currently available for this branch.