### PR TITLE
enhancement, defer issue phone paired event

### DIFF
--- a/controllers/netbot.js
+++ b/controllers/netbot.js
@@ -29,6 +29,8 @@ const sem = require('../sensor/SensorEventManager.js').getInstance();
 
 const fc = require('../net2/config.js')
 const pairedMaxHistoryEntry = fc.getConfig().pairedDeviceMaxHistory || 100;
+// event types whose notification is on until the app explicitly turns it off, same as alarms
+const DEFAULT_ON_EVENT_TYPES = ["phone_paired"];
 const URL = require("url");
 const bone = require("../lib/Bone");
 
@@ -151,6 +153,7 @@ const RateLimiterRedis = require('../vendor_lib/rate-limiter-flexible/RateLimite
 const RateLimiterRes = require('../vendor_lib/rate-limiter-flexible/RateLimiterRes');
 const cpuProfile = require('../net2/CpuProfile.js');
 const ea = require('../event/EventApi.js');
+const pairedAppEventTool = require('../net2/PairedAppEventTool.js');
 const { Rule } = require('../net2/Iptables.js');
 const iptc = require('../control/IptablesControl.js');
 const sl = require('../sensor/APISensorLoader.js');
@@ -304,7 +307,11 @@ class netBot extends ControllerBot {
     nm.loadConfig();
   }
 
-  // by default, all event-based notifications are disabled (alarms by default enabled)
+  /*
+   * By default, event-based notifications are disabled and have to be turned on per event type,
+   * except the types in DEFAULT_ON_EVENT_TYPES, which are on unless the app explicitly turns them
+   * off. The global switch always wins, an unset one is still taken as off.
+   */
   _checkEventNotifyPolicy(policy, event_type) {
     if (!policy || !policy["notify"]) {
       log.info("host notification policy not set, skip notification");
@@ -316,7 +323,16 @@ class netBot extends ControllerBot {
       return false;
     }
 
-    if (!policy["notify"][event_type]) {
+    const state = policy["notify"][event_type];
+    if (state === undefined || state === null) {
+      if (!DEFAULT_ON_EVENT_TYPES.includes(event_type)) {
+        log.info("host event notification not set for event type", event_type);
+        return false;
+      }
+      return true;
+    }
+
+    if (!state) {
       log.info("host event notification disable for event type", event_type);
       return false;
     }
@@ -353,7 +369,7 @@ class netBot extends ControllerBot {
     }
 
     let notifEvent = await this.getNotifEvent(event_type, event_value, event.labels);
-    if (notifEvent.msg == "") {
+    if (!notifEvent || !notifEvent.msg) {
       log.info(`event ${event_type} not supported for notification`);
       return;
     }
@@ -364,29 +380,33 @@ class netBot extends ControllerBot {
       bodyKey: 'NOTIF_EVENT_BODY',
       titleLocalKey: `NEW_EVENT_TITLE_${event_type}`,
       bodyLocalKey: `NEW_EVENT_BODY_${event_type}`,
-      bodyLocalArgs: [notifEvent.args.eid, notifEvent.args.deviceName || "", notifEvent.args.ts || 0 ],
+      bodyLocalArgs: !_.isEmpty(notifEvent.localArgs) ? notifEvent.localArgs
+        : [notifEvent.args.eid, notifEvent.args.deviceName || "", notifEvent.args.ts || 0 ],
       bodyLocalMsg: notifEvent.msg,
       payload: notifEvent.args,
     }
   }
 
   async getNotifEvent(event_type, event_value, event_labels) {
-    let payload = {msg: '', args: {}};
+    let payload = {msg: '', args: {}, localArgs: []};
+    if (!event_labels) return payload;
     switch (event_type) {
-      case "phone_paired":
+      case "phone_paired": {
         const eid = event_labels.eid;
-        const deviceName = event_labels.deviceName;
-        if (eid == "") return;
-        payload.msg = `A new phone ${deviceName ? "("+deviceName+") " : ""}is paired with your Firewalla box.`;
+        // dName comes from the appInfo of the paired app, deviceName is the label of legacy events
+        const dName = event_labels.dName || event_labels.deviceName || "";
+        const name = event_labels.name || ""; // account of the paired app
+        const ts = event_labels.ts || 0;
+        if (!eid) break;
+        payload.msg = `A new phone ${dName ? "("+dName+") " : ""}is paired with your Firewalla box.`;
         payload.args.eid = eid;
-        payload.args.deviceName = deviceName || "";
-        // find latest event ts
-        let results = await ea.getLatestEventsByType(event_type);
-        results = results.filter(i => i.labels && i.labels.eid == eid);
-        if (results.length > 0) {
-          payload.args.ts = results[0].ts
-        }
+        payload.args.dName = dName;
+        payload.args.deviceName = dName; // legacy key, kept for apps that do not read dName yet
+        payload.args.name = name;
+        payload.args.ts = ts;
+        payload.localArgs = [eid, dName, ts, name];
         break;
+      }
       default:
     }
     return payload
@@ -1236,23 +1256,18 @@ class netBot extends ControllerBot {
             const date = Math.floor(Date.now() / 1000)
             result["msg"] = `${historyMsg}paired at ${date},`;
             await rclient.hsetAsync("sys:ept:members:history", appInfo.eid, JSON.stringify(result));
-             // notify phone_pair events
-            sem.sendEventToFireApi({
-              type: `Event:NewEvent`,
-              message: "A new event is generated",
-              event: {
-                  "event_type": "action",
-                  "action_type": "phone_paired",
-                  "action_value": 1,
-                  "labels": {"eid": appInfo.eid, "deviceName": appInfo.deviceName}
-              },
-            });
           }
         }
       } catch (err) {
         log.info("error when record paired device history info", err)
       }
       await rclient.hsetAsync(keyName, appInfo.eid, appInfo.deviceName)
+
+      // fire the phone_paired event of a freshly paired app, this is the first time its device name
+      // is known. Nothing happens if there is no pending record, i.e. the app is not newly paired
+      await pairedAppEventTool.claimPending(appInfo.eid, appInfo.deviceName).catch((err) => {
+        log.error("Failed to fire phone_paired event of", appInfo.eid, err.message)
+      })
 
       const keyName2 = "sys:ept:member:lastvisit"
       await rclient.hsetAsync(keyName2, appInfo.eid, Math.floor(Date.now() / 1000))

--- a/net2/Constants.js
+++ b/net2/Constants.js
@@ -50,6 +50,7 @@ module.exports = {
 
   REDIS_KEY_EID_REVOKE_SET: "sys:ept:members:revoked",
   REDIS_KEY_EPT_MEMBER_EMAILS: "sys:ept:memberEmails",
+  REDIS_KEY_EPT_PAIRED_PENDING: "sys:ept:pairedPending",
   REDIS_KEY_GROUP_NAME: "groupName",
   REDIS_KEY_DDNS_UPDATE: "ddns:update",
   REDIS_KEY_CPU_USAGE: "cpu_usage_records",

--- a/net2/PairedAppEventTool.js
+++ b/net2/PairedAppEventTool.js
@@ -1,0 +1,143 @@
+/*    Copyright 2026 Firewalla Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+'use strict';
+
+const log = require('./logger.js')(__filename);
+
+const rclient = require('../util/redis_manager.js').getRedisClient();
+const Constants = require('./Constants.js');
+const era = require('../event/EventRequestApi.js');
+const sem = require('../sensor/SensorEventManager.js').getInstance();
+
+const KEY_PAIRED_PENDING = Constants.REDIS_KEY_EPT_PAIRED_PENDING;
+const EVENT_TYPE = "phone_paired";
+
+/*
+ * Device name of a freshly paired app is NOT known at pairing time, it only comes with the appInfo
+ * of the first init request, usually 20s ~ 1min later. So instead of firing the phone_paired event
+ * right away in FireKick, pairing only leaves a pending record in redis:
+ *
+ *   sys:ept:pairedPending: { <eid>: {"ts":<pairing time>,"name":<account>,"dName":<device name>} }
+ *
+ * and the event is fired later on whichever comes first:
+ * - netbot gets the first appInfo carrying deviceName          -> claimPending()
+ * - PairedAppSensor finds the record expired or already named  -> flushPending()
+ *
+ * hdel of the pending record is the lock, only the caller that actually removes it fires the event,
+ * so the event is fired exactly once no matter how many times the app inits.
+ */
+class PairedAppEventTool {
+
+  // called by FireKick right after an app is linked to the group
+  async addPending(eid, info = {}) {
+    if (!eid) return;
+    const record = Object.assign({}, info, { ts: info.ts || Date.now() });
+    log.forceInfo(`Record pending paired app ${eid}`, record);
+    await rclient.hsetAsync(KEY_PAIRED_PENDING, eid, JSON.stringify(record));
+  }
+
+  async removePending(eid) {
+    if (!eid) return;
+    await rclient.hdelAsync(KEY_PAIRED_PENDING, eid);
+  }
+
+  /*
+   * Fire the pending phone_paired event of an eid, dName overrides the one in the pending record.
+   * Returns true if the event is fired by this call.
+   */
+  async claimPending(eid, dName = null) {
+    if (!eid) return false;
+
+    const payload = await rclient.hgetAsync(KEY_PAIRED_PENDING, eid);
+    if (!payload) return false;
+
+    // whoever removes the pending record owns the event
+    const removed = await rclient.hdelAsync(KEY_PAIRED_PENDING, eid);
+    if (!removed) return false;
+
+    let info = {};
+    try {
+      info = JSON.parse(payload) || {};
+    } catch (err) {
+      log.error(`Failed to parse pending paired record of ${eid}: ${payload}`, err.message);
+    }
+    if (dName) info.dName = dName;
+
+    await this.emitPairedEvent(eid, info);
+    return true;
+  }
+
+  /*
+   * timeout : fire the event without dName if app does not init in time, in milliseconds
+   * stale   : pending records older than this are dropped silently, they are most likely
+   *           brought in by a restored backup instead of a real pairing, in milliseconds
+   */
+  async flushPending(timeout, stale) {
+    const pending = await rclient.hgetallAsync(KEY_PAIRED_PENDING);
+    if (!pending) return;
+
+    const now = Date.now();
+    for (const eid of Object.keys(pending)) {
+      let info = null;
+      try {
+        info = JSON.parse(pending[eid]);
+      } catch (err) {
+        log.error(`Failed to parse pending paired record of ${eid}: ${pending[eid]}`, err.message);
+      }
+
+      if (!info || !info.ts) {
+        log.error(`Drop invalid pending paired record of ${eid}`, pending[eid]);
+        await this.removePending(eid);
+        continue;
+      }
+
+      const age = now - info.ts;
+      if (age > stale) {
+        log.warn(`Drop stale pending paired record of ${eid}, paired ${Math.floor(age / 1000)} seconds ago`);
+        await this.removePending(eid);
+        continue;
+      }
+
+      // keep waiting for the init request as long as device name is still unknown
+      if (!info.dName && age < timeout) continue;
+
+      await this.claimPending(eid);
+    }
+  }
+
+  async emitPairedEvent(eid, info = {}) {
+    const ts = info.ts || Date.now();
+    const labels = { eid, ts };
+    if (info.name) labels.name = info.name;
+    if (info.dName) labels.dName = info.dName;
+
+    log.forceInfo(`Fire ${EVENT_TYPE} event of ${eid}`, labels);
+    await era.addActionEvent(EVENT_TYPE, 1, labels, ts);
+
+    // notification is sent by netbot in FireApi
+    sem.sendEventToFireApi({
+      type: "Event:NewEvent",
+      message: "A new event is generated",
+      event: {
+        "event_type": "action",
+        "action_type": EVENT_TYPE,
+        "action_value": 1,
+        "labels": labels
+      },
+    });
+  }
+}
+
+module.exports = new PairedAppEventTool();

--- a/net2/config.json
+++ b/net2/config.json
@@ -106,6 +106,11 @@
     "AdditionalPairPlugin": {},
     "DockerPlugin": {},
     "EncipherPlugin": {},
+    "PairedAppSensor": {
+      "pendingTimeout": 120,
+      "checkInterval": 60,
+      "staleThreshold": 3600
+    },
     "GuardianSensor": {},
     "DNSCryptPlugin": {},
     "UnboundPlugin": {},

--- a/sensor/EncipherPlugin.js
+++ b/sensor/EncipherPlugin.js
@@ -26,6 +26,7 @@ const encipherTool = new EncipherTool()
 
 const rclient = require('../util/redis_manager.js').getRedisClient();
 const f = require('../net2/Firewalla.js');
+const pairedAppEventTool = require('../net2/PairedAppEventTool.js');
 
 class EncipherPlugin extends Sensor {
 
@@ -92,6 +93,8 @@ class EncipherPlugin extends Sensor {
     await rclient.hdelAsync("sys:ept:member:lastvisit", eid);
     await rclient.hdelAsync(Constants.REDIS_KEY_EPT_MEMBER_EMAILS, eid);
     await rclient.saddAsync(Constants.REDIS_KEY_EID_REVOKE_SET, eid);
+    // in case the app is unpaired before its phone_paired event is fired
+    await pairedAppEventTool.removePending(eid);
 
     try {
       const historyStr = await rclient.hgetAsync("sys:ept:members:history", eid);

--- a/sensor/PairedAppSensor.js
+++ b/sensor/PairedAppSensor.js
@@ -1,0 +1,52 @@
+/*    Copyright 2026 Firewalla Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+'use strict';
+
+const log = require('../net2/logger.js')(__filename);
+
+const Sensor = require('./Sensor.js').Sensor;
+const pairedAppEventTool = require('../net2/PairedAppEventTool.js');
+
+const DEFAULT_PENDING_TIMEOUT = 120; // seconds an app has to send its first init before the event is fired without device name
+const DEFAULT_CHECK_INTERVAL = 60; // seconds
+const DEFAULT_STALE_THRESHOLD = 3600; // seconds, a pending record older than this is not a real pairing
+
+/*
+ * Backstop of the phone_paired event, see net2/PairedAppEventTool.js. netbot fires the event as soon
+ * as the paired app sends its first init request, this sensor covers the app that never does.
+ */
+class PairedAppSensor extends Sensor {
+
+  async apiRun() {
+    // FireApi is started by FireKick right after the very first pairing, so pending records may
+    // already be there before the first interval kicks in
+    await this.checkPendingPairedApps();
+
+    const interval = (this.config.checkInterval || DEFAULT_CHECK_INTERVAL) * 1000;
+    setInterval(() => {
+      this.checkPendingPairedApps();
+    }, interval);
+  }
+
+  async checkPendingPairedApps() {
+    const timeout = (this.config.pendingTimeout || DEFAULT_PENDING_TIMEOUT) * 1000;
+    const stale = (this.config.staleThreshold || DEFAULT_STALE_THRESHOLD) * 1000;
+    await pairedAppEventTool.flushPending(timeout, stale).catch((err) => {
+      log.error("Failed to check pending paired apps", err.message);
+    });
+  }
+}
+
+module.exports = PairedAppSensor;

--- a/sys/invitation.js
+++ b/sys/invitation.js
@@ -43,7 +43,7 @@ const clientMgmt = require('../mgmt/ClientMgmt.js');
 const config = require('../net2/config.js').getConfig();
 
 const sysManager = require('../net2/SysManager.js');
-const era = require('../event/EventRequestApi.js');
+const pairedAppEventTool = require('../net2/PairedAppEventTool.js');
 const Constants = require('../net2/Constants.js');
 
 const FW_SERVICE = "Firewalla";
@@ -379,10 +379,12 @@ class FWInvitation {
       // remove from revoked eid set
       await rclient.sremAsync(Constants.REDIS_KEY_EID_REVOKE_SET, eid);
 
-      // fire an event on phone_paired with the paired app info
-      const ts = Date.now();
-      const labels = Object.assign(await this.getPairedMemberInfo(eid), {"eid":eid, "ts":ts});
-      await era.addActionEvent("phone_paired",1,labels,ts);
+      // dName of a brand new app is not available at this moment, it only comes with the appInfo of
+      // the first init request. Leave a pending record here and let FireApi fire the phone_paired
+      // event once dName is known, or once the pending record expires. FireMain may not even be
+      // running yet on the very first pairing, an event fired here would simply be lost.
+      const memberInfo = await this.getPairedMemberInfo(eid);
+      await pairedAppEventTool.addPending(eid, Object.assign(memberInfo, {"ts": Date.now()}));
 
       log.forceInfo(`Linked App ${eid} to this device successfully`);
 

--- a/test/test_netbot.js
+++ b/test/test_netbot.js
@@ -729,26 +729,62 @@ describe('test netbot', function(){
   });
 
   it('should get event message', async() => {
+    expect(await netbot.getNotifEvent("phone_paired", 1, {"eid": "7wZYL2pk6hkzF313f8FkIA", "name": "my1@firewalla.com", "dName": "Device-abc", "ts": 1743556883664})).to.be.eql({
+      "msg": "A new phone (Device-abc) is paired with your Firewalla box.",
+      "args": {eid: "7wZYL2pk6hkzF313f8FkIA", dName: "Device-abc", deviceName: "Device-abc", name: "my1@firewalla.com", ts: 1743556883664},
+      "localArgs": ["7wZYL2pk6hkzF313f8FkIA", "Device-abc", 1743556883664, "my1@firewalla.com"],
+    })
+  });
+
+  it('should get event message of legacy phone_paired labels', async() => {
     expect(await netbot.getNotifEvent("phone_paired", 1, {"eid": "7wZYL2pk6hkzF313f8FkIA", "deviceName": "Device-abc"})).to.be.eql({
       "msg": "A new phone (Device-abc) is paired with your Firewalla box.",
-      "args": {eid: "7wZYL2pk6hkzF313f8FkIA", deviceName: "Device-abc"},
+      "args": {eid: "7wZYL2pk6hkzF313f8FkIA", dName: "Device-abc", deviceName: "Device-abc", name: "", ts: 0},
+      "localArgs": ["7wZYL2pk6hkzF313f8FkIA", "Device-abc", 0, ""],
     })
+  });
+
+  it('should get event message without device name', async() => {
+    const payload = await netbot.getNotifEvent("phone_paired", 1, {"eid": "7wZYL2pk6hkzF313f8FkIA", "name": "my1@firewalla.com", "ts": 1743556883664});
+    expect(payload.msg).to.be.equal("A new phone is paired with your Firewalla box.");
+    expect(payload.localArgs).to.be.eql(["7wZYL2pk6hkzF313f8FkIA", "", 1743556883664, "my1@firewalla.com"]);
+  });
+
+  it('should not get event message of unsupported event type', async() => {
+    const payload = await netbot.getNotifEvent("no_such_event", 1, {});
+    expect(payload.msg).to.be.equal('');
   });
 
   it('should notify new event', async () => {
     netbot.hostManager.policy = {"notify": { "state": true, "phone_paired": true }};
 
-    const event = { "ts": 1743556883664, "event_type": "action", "action_type": "phone_paired", "action_value": 1, "labels": { "eid": "7wZYL2pk6hkzF313f8FkIA", "deviceName": "Device-abc" } }
+    const event = { "ts": 1743556883664, "event_type": "action", "action_type": "phone_paired", "action_value": 1, "labels": { "eid": "7wZYL2pk6hkzF313f8FkIA", "name": "my1@firewalla.com", "dName": "Device-abc", "ts": 1743556883664 } }
     const payload = await netbot._notifyNewEvent(event);
     expect(payload.type).to.be.equal('FW_NOTIFICATION');
     expect(payload.titleLocalKey).to.be.equal('NEW_EVENT_TITLE_phone_paired');
     expect(payload.bodyLocalMsg).to.be.equal("A new phone (Device-abc) is paired with your Firewalla box.");
-    expect(payload.bodyLocalArgs).to.be.eql(["7wZYL2pk6hkzF313f8FkIA", "Device-abc", 0]);
+    expect(payload.bodyLocalArgs).to.be.eql(["7wZYL2pk6hkzF313f8FkIA", "Device-abc", 1743556883664, "my1@firewalla.com"]);
+    expect(payload.payload.dName).to.be.equal("Device-abc");
+    expect(payload.payload.name).to.be.equal("my1@firewalla.com");
   });
 
   it('should not notify new event if policy is not set', async () => {
-    const event = { "ts": 1743556883664, "event_type": "action", "action_type": "phone_paired", "action_value": 1, "labels": { "eid": "7wZYL2pk6hkzF313f8FkIA", "deviceName": "Device-abc" } }
+    const event = { "ts": 1743556883664, "event_type": "action", "action_type": "phone_paired", "action_value": 1, "labels": { "eid": "7wZYL2pk6hkzF313f8FkIA", "dName": "Device-abc" } }
     netbot.hostManager.policy = {};
+    const payload = await netbot._notifyNewEvent(event);
+    expect(payload).to.be.undefined;
+  });
+
+  it('should notify new event if event type switch is not set', async () => {
+    const event = { "ts": 1743556883664, "event_type": "action", "action_type": "phone_paired", "action_value": 1, "labels": { "eid": "7wZYL2pk6hkzF313f8FkIA", "dName": "Device-abc" } }
+    netbot.hostManager.policy = {"notify": { "state": true }};
+    const payload = await netbot._notifyNewEvent(event);
+    expect(payload.type).to.be.equal('FW_NOTIFICATION');
+  });
+
+  it('should not notify new event if policy is turned off', async () => {
+    const event = { "ts": 1743556883664, "event_type": "action", "action_type": "phone_paired", "action_value": 1, "labels": { "eid": "7wZYL2pk6hkzF313f8FkIA", "dName": "Device-abc" } }
+    netbot.hostManager.policy = {"notify": { "state": true, "phone_paired": false }};
     const payload = await netbot._notifyNewEvent(event);
     expect(payload).to.be.undefined;
   });
@@ -758,6 +794,19 @@ describe('test netbot', function(){
     expect(netbot._checkEventNotifyPolicy({ "notify": {} }, "test")).to.be.false;
     expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 1 } }, "test")).to.be.false;
     expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 1, "test": true } }, "test")).to.be.true;
+  });
+
+  it('should check event notify policy of default on event type', async () => {
+    // global switch always wins, an unset one is taken as off
+    expect(netbot._checkEventNotifyPolicy({}, "phone_paired")).to.be.false;
+    expect(netbot._checkEventNotifyPolicy({ "notify": {} }, "phone_paired")).to.be.false;
+    // notification of phone_paired is on unless it is explicitly turned off
+    expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 1 } }, "phone_paired")).to.be.true;
+    expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 1, "phone_paired": true } }, "phone_paired")).to.be.true;
+    expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 1, "phone_paired": false } }, "phone_paired")).to.be.false;
+    expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 1, "phone_paired": 0 } }, "phone_paired")).to.be.false;
+    expect(netbot._checkEventNotifyPolicy({ "notify": { "state": false } }, "phone_paired")).to.be.false;
+    expect(netbot._checkEventNotifyPolicy({ "notify": { "state": 0 } }, "phone_paired")).to.be.false;
   });
 
 });


### PR DESCRIPTION
1. defer issue phone paired event in order to get the device name from the first app request
2. update notification data for new phone paired.