### PR TITLE
category: make user target list deactivation decide in FireMain

### DIFF
--- a/alarm/ExceptionManager.js
+++ b/alarm/ExceptionManager.js
@@ -120,10 +120,22 @@ module.exports = class {
     return exceptions.some(e => e.getCategory() === category);
   }
 
+  // Whether any rule or exception still needs this category. Must be re-evaluated right before
+  // the destructive cleanup, not just when the deactivation is decided: the two are separated by
+  // an event hop, and a rule/exception can reference the target list again in between.
+  async isCategoryReferenced(category) {
+    if (!category) return false;
+    if (categoryUpdater.hasActivePolicies(category)) return true;
+    if (await this.hasException(category)) return true;
+    // lazy require, PolicyManager2 requires this module at load time
+    const PolicyManager2 = require('./PolicyManager2.js');
+    return new PolicyManager2().hasPersistedCategoryPolicy(category);
+  }
+
   // User target list categories are only kept alive by the rules/exceptions referencing them.
-  // Both checks below read FireMain-only in-memory state (activeCategoryPolicyMap, activeCategories),
-  // so other processes must hand the decision over instead of silently no-op'ing here.
-  // Rule delete and exception delete both funnel through this, so whichever lands last cleans up.
+  // isCategoryReferenced() and deactivateCategory() both read FireMain-only in-memory state, so
+  // other processes must hand the decision over instead of silently no-op'ing here. Rule delete
+  // and exception delete both funnel through this, so whichever lands last cleans up.
   async maybeDeactivateCategory(category) {
     if (!category || !categoryUpdater.isUserTargetList(category)) return;
     if (!firewalla.isMain()) {
@@ -135,8 +147,7 @@ module.exports = class {
       });
       return;
     }
-    if (categoryUpdater.hasActivePolicies(category)) return;
-    if (await this.hasException(category)) return;
+    if (await this.isCategoryReferenced(category)) return;
     await categoryUpdater.deactivateCategory(category);
   }
 

--- a/alarm/ExceptionManager.js
+++ b/alarm/ExceptionManager.js
@@ -120,11 +120,21 @@ module.exports = class {
     return exceptions.some(e => e.getCategory() === category);
   }
 
-  // user target list categories are only kept alive by rules/exceptions referencing them;
-  // once the last exception referencing one is removed, stop polling its hashset if no rule
-  // is using it either, instead of leaving it active until the next reboot
-  async _maybeDeactivateCategory(category) {
+  // User target list categories are only kept alive by the rules/exceptions referencing them.
+  // Both checks below read FireMain-only in-memory state (activeCategoryPolicyMap, activeCategories),
+  // so other processes must hand the decision over instead of silently no-op'ing here.
+  // Rule delete and exception delete both funnel through this, so whichever lands last cleans up.
+  async maybeDeactivateCategory(category) {
     if (!category || !categoryUpdater.isUserTargetList(category)) return;
+    if (!firewalla.isMain()) {
+      sem.emitEvent({
+        type: "Category:MaybeDeactivate",
+        toProcess: "FireMain",
+        message: "Check whether category can be deactivated: " + category,
+        category: category
+      });
+      return;
+    }
     if (categoryUpdater.hasActivePolicies(category)) return;
     if (await this.hasException(category)) return;
     await categoryUpdater.deactivateCategory(category);
@@ -379,7 +389,7 @@ module.exports = class {
     Bone.submitIntelFeedback('unignore', exception);
 
     if (exception && exception['p.category.id']) {
-      await this._maybeDeactivateCategory(exception['p.category.id']);
+      await this.maybeDeactivateCategory(exception['p.category.id']);
     }
   }
 
@@ -396,7 +406,7 @@ module.exports = class {
       await rclient.sremAsync(exceptionQueue, idList);
 
       for (const category of categories) {
-        await this._maybeDeactivateCategory(category);
+        await this.maybeDeactivateCategory(category);
       }
     }
   }

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -625,6 +625,15 @@ class PolicyManager2 {
     return formattedPolicy;
   }
 
+  // Whether any enabled rule persisted in redis still targets this category. Rules are saved
+  // before they are enforced, and enforce() activates the category before updateCategoryState()
+  // records it, so activeCategoryPolicyMap alone has a window where a live rule is invisible.
+  async hasPersistedCategoryPolicy(target) {
+    const count = await this.countActivePolicyNumber();
+    const policies = await this.loadActivePoliciesAsync({ number: count });
+    return (policies || []).some(p => p.target === target);
+  }
+
   async getSamePolicies(policy) {
     const count = await this.countActivePolicyNumber()
     let policies = await this.loadActivePoliciesAsync({ includingDisabled: true, number: count });

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -2709,11 +2709,7 @@ class PolicyManager2 {
           // user target list categories are activated on demand and never deactivated by the
           // built-in category refresh logic; once the last rule referencing one is removed,
           // stop polling its hashset instead of leaving it active until the next reboot
-          if (categoryUpdater.isUserTargetList(target) &&
-            !categoryUpdater.hasActivePolicies(target) &&
-            !(await exceptionManager.hasException(target))) {
-            await categoryUpdater.deactivateCategory(target);
-          }
+          await exceptionManager.maybeDeactivateCategory(target);
         }
 
         if (["allow", "block", "route"].includes(action)) {

--- a/sensor/CategoryUpdateSensor.js
+++ b/sensor/CategoryUpdateSensor.js
@@ -30,6 +30,8 @@ const CategoryUpdater = require('../control/CategoryUpdater.js');
 const categoryUpdater = new CategoryUpdater();
 const CountryUpdater = require('../control/CountryUpdater.js');
 const countryUpdater = new CountryUpdater();
+const ExceptionManager = require('../alarm/ExceptionManager.js');
+const exceptionManager = new ExceptionManager();
 
 const { Address4, Address6 } = require('ip-address');
 
@@ -635,12 +637,25 @@ class CategoryUpdateSensor extends Sensor {
         }
       });
 
+      // deciding whether a user target list still has a rule/exception behind it needs state that
+      // only exists in this process, so FireApi/FireMon delegate the check here
+      sem.on('Category:MaybeDeactivate', async (event) => {
+        await exceptionManager.maybeDeactivateCategory(event.category).catch((err) => {
+          log.error("Failed to check category deactivation", event.category, err.message);
+        });
+      })
+
       sem.on('Category:Delete', async (event) => {
         log.info("Deactivate category", event.category);
         const category = event.category;
         await categoryUpdater.clearRecycleTask(category);
         if (!categoryUpdater.isCustomizedCategory(category) &&
           categoryUpdater.activeCategories[category]) {
+          // user target lists are loaded through cloudcache, whose own job keeps refreshing
+          // registered items regardless of whether the category is still active
+          const hashset = this.getCategoryHashset(category);
+          if (hashset && categoryUpdater.isUserTargetList(category))
+            await cloudcache.disableCache(hashset);
           delete categoryUpdater.activeCategories[category];
           delete this.categoryHashsetMapping[category];
           await categoryUpdater.flushDefaultDomains(category);

--- a/sensor/CategoryUpdateSensor.js
+++ b/sensor/CategoryUpdateSensor.js
@@ -643,11 +643,18 @@ class CategoryUpdateSensor extends Sensor {
         await exceptionManager.maybeDeactivateCategory(event.category).catch((err) => {
           log.error("Failed to check category deactivation", event.category, err.message);
         });
-      })
+      });
 
       sem.on('Category:Delete', async (event) => {
         log.info("Deactivate category", event.category);
         const category = event.category;
+        // deactivation was decided before this event was delivered, re-check right before the
+        // flushes so a target list referenced again in the meantime doesn't get its data wiped
+        if (categoryUpdater.isUserTargetList(category) &&
+          await exceptionManager.isCategoryReferenced(category)) {
+          log.info("Category is referenced again, skip deactivation", category);
+          return;
+        }
         await categoryUpdater.clearRecycleTask(category);
         if (!categoryUpdater.isCustomizedCategory(category) &&
           categoryUpdater.activeCategories[category]) {

--- a/sensor/Guardian.js
+++ b/sensor/Guardian.js
@@ -38,6 +38,7 @@ const rp = require('request-promise');
 const PolicyManager2 = require('../alarm/PolicyManager2.js');
 const LiveTransport = require('./LiveTransport.js');
 const pm2 = new PolicyManager2();
+const sem = require('./SensorEventManager.js').getInstance();
 const ExceptionManager = require('../alarm/ExceptionManager.js');
 const exceptionManager = new ExceptionManager();
 
@@ -551,6 +552,12 @@ module.exports = class {
       if (mspRelatedEids.length) {
         log.info("Remove msp exceptions", mspRelatedEids);
         await exceptionManager.deleteExceptions(mspRelatedEids);
+        // same notification netbot sends on exception:delete, otherwise FireMain keeps a stale
+        // CategoryMatcher for the removed exception and can re-activate its target list
+        sem.sendEventToOthers({
+          type: "ExceptionChange",
+          message: "msp exceptions removed"
+        });
       }
 
       // reset no_auto_upgrade flags


### PR DESCRIPTION
Deleting the last rule/exception on a user target list (TL-*) still left CategoryUpdateSensor polling its hashset, so a box removed from an MSP kept logging "Fail to fetch category list from cloud" forever.

Both guards of the exception path read FireMain-only in-memory state: hasActivePolicies() reads activeCategoryPolicyMap and deactivateCategory() early-returns on isActivated(), which reads activeCategories. Exception deletes run in FireApi (netbot exception:delete, Guardian.reset), where both are always empty, so the path never emitted Category:Delete and FireMain kept the category active.

The rule path runs in FireMain and works, but its unenforce is dispatched cross-process without awaiting, so when a rule and an exception reference the same target list the two deletes race: whichever runs first sees the other one still present and skips deactivation.

Funnel both paths through ExceptionManager.maybeDeactivateCategory(), which hands the decision to FireMain via a new Category:MaybeDeactivate event when called elsewhere. Both deletes now re-run the same idempotent check, so whichever lands last performs the cleanup regardless of order.

Also:
- Guardian.reset() now sends ExceptionChange like netbot does on exception:delete, otherwise FireMain keeps a stale CategoryMatcher that re-activates the target list on the next UPDATE_CATEGORY_DOMAIN.
- Category:Delete disables the cloudcache item of a user target list; cloudcache's own job refreshes registered items regardless of whether the category is still active.

Fixes firewalla/firecommit#9299