### PR TITLE
Revert "category: revalidate references before flushing a target list"

### DIFF
--- a/alarm/ExceptionManager.js
+++ b/alarm/ExceptionManager.js
@@ -120,22 +120,10 @@ module.exports = class {
     return exceptions.some(e => e.getCategory() === category);
   }
 
-  // Whether any rule or exception still needs this category. Must be re-evaluated right before
-  // the destructive cleanup, not just when the deactivation is decided: the two are separated by
-  // an event hop, and a rule/exception can reference the target list again in between.
-  async isCategoryReferenced(category) {
-    if (!category) return false;
-    if (categoryUpdater.hasActivePolicies(category)) return true;
-    if (await this.hasException(category)) return true;
-    // lazy require, PolicyManager2 requires this module at load time
-    const PolicyManager2 = require('./PolicyManager2.js');
-    return new PolicyManager2().hasPersistedCategoryPolicy(category);
-  }
-
   // User target list categories are only kept alive by the rules/exceptions referencing them.
-  // isCategoryReferenced() and deactivateCategory() both read FireMain-only in-memory state, so
-  // other processes must hand the decision over instead of silently no-op'ing here. Rule delete
-  // and exception delete both funnel through this, so whichever lands last cleans up.
+  // Both checks below read FireMain-only in-memory state (activeCategoryPolicyMap, activeCategories),
+  // so other processes must hand the decision over instead of silently no-op'ing here.
+  // Rule delete and exception delete both funnel through this, so whichever lands last cleans up.
   async maybeDeactivateCategory(category) {
     if (!category || !categoryUpdater.isUserTargetList(category)) return;
     if (!firewalla.isMain()) {
@@ -147,7 +135,8 @@ module.exports = class {
       });
       return;
     }
-    if (await this.isCategoryReferenced(category)) return;
+    if (categoryUpdater.hasActivePolicies(category)) return;
+    if (await this.hasException(category)) return;
     await categoryUpdater.deactivateCategory(category);
   }
 

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -625,15 +625,6 @@ class PolicyManager2 {
     return formattedPolicy;
   }
 
-  // Whether any enabled rule persisted in redis still targets this category. Rules are saved
-  // before they are enforced, and enforce() activates the category before updateCategoryState()
-  // records it, so activeCategoryPolicyMap alone has a window where a live rule is invisible.
-  async hasPersistedCategoryPolicy(target) {
-    const count = await this.countActivePolicyNumber();
-    const policies = await this.loadActivePoliciesAsync({ number: count });
-    return (policies || []).some(p => p.target === target);
-  }
-
   async getSamePolicies(policy) {
     const count = await this.countActivePolicyNumber()
     let policies = await this.loadActivePoliciesAsync({ includingDisabled: true, number: count });

--- a/sensor/CategoryUpdateSensor.js
+++ b/sensor/CategoryUpdateSensor.js
@@ -643,18 +643,11 @@ class CategoryUpdateSensor extends Sensor {
         await exceptionManager.maybeDeactivateCategory(event.category).catch((err) => {
           log.error("Failed to check category deactivation", event.category, err.message);
         });
-      });
+      })
 
       sem.on('Category:Delete', async (event) => {
         log.info("Deactivate category", event.category);
         const category = event.category;
-        // deactivation was decided before this event was delivered, re-check right before the
-        // flushes so a target list referenced again in the meantime doesn't get its data wiped
-        if (categoryUpdater.isUserTargetList(category) &&
-          await exceptionManager.isCategoryReferenced(category)) {
-          log.info("Category is referenced again, skip deactivation", category);
-          return;
-        }
         await categoryUpdater.clearRecycleTask(category);
         if (!categoryUpdater.isCustomizedCategory(category) &&
           categoryUpdater.activeCategories[category]) {


### PR DESCRIPTION
Reverts 35151dab906a5e7ce2abe0eacb57ac8ad5165e1b, merged in #9561.

That commit re-validated rule/exception references immediately before the `Category:Delete` cleanup, to cover the case where the last reference to a user target list is removed and a new one appears within the same event delivery. In practice that window is short enough not to justify the cost: `ExceptionManager.isCategoryReferenced()` called `PolicyManager2.hasPersistedCategoryPolicy()`, which loads every active policy from redis via `loadActivePoliciesAsync()` on each deactivation check.

The actual fix for firewalla/firecommit#9299 (ee4c7addb, also in #9561) is untouched and stands on its own — it never referenced `isCategoryReferenced()` or `hasPersistedCategoryPolicy()`. After this revert `maybeDeactivateCategory()` goes back to the two inline checks:

```js
if (categoryUpdater.hasActivePolicies(category)) return;
if (await this.hasException(category)) return;
await categoryUpdater.deactivateCategory(category);
```

Deactivation still gets decided in FireMain, both the rule and the exception delete path still funnel through the same entry point, and the ordering race between them stays fixed.

Known trade-off: if the last reference is removed and the target list is referenced again within the same `Category:Delete` delivery (e.g. an MSP mute-rule edit, which deletes and recreates the exception), the newly created rule/exception can have its category data flushed and would recover on the next rule change or reboot.