### PR TITLE
ci: cut webpack workflow runtime from ~30min to a few minutes

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -26,21 +26,34 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Checkout fnm
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: firewalla/fnm.node8.x86_64
           path: fnm
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
 
+      # There is no lockfile in this repo, so setup-node's built-in cache can't be
+      # used; cache npm's download directory directly instead. Keyed on
+      # package.json so the cache rolls over whenever dependencies change.
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-node16-${{ hashFiles('package.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-node16-
+
       - run: npm install -g eslint@8.57.1
       - run: eslint --quiet ./ # todo, only eslint for diff files
-      - run: npm i -g yarn
+      # yarn ships with the ubuntu runner image; installing it again cost between
+      # one and seven minutes per run.
+      - run: yarn --version || npm i -g yarn
       - run: yarn global add webpack-cli@5.1.4
       - run: mkdir -p webpack; cd webpack; yarn add webpack webpack-cli || true
       - run: $(yarn global bin)/webpack-cli -c .webpack/config_main.js

--- a/.webpack/prep-env.sh
+++ b/.webpack/prep-env.sh
@@ -4,16 +4,21 @@
 pwd
 echo $NODE_PATH
 sudo mkdir -p /home/pi
-sudo ln -s /home/runner/work/firewalla/firewalla /home/pi/firewalla
+sudo ln -sfn /home/runner/work/firewalla/firewalla /home/pi/firewalla
 sudo ls -l /home/pi/firewalla
 
-npm i nyc@15.1.0
-npm i -g mocha@^9.2.2
-npm i jsbn@1.1.0
-npm i lru-cache@5.1.1
-npm i moment-timezone@0.3.1
-npm i muk@0.5.3
-npm i async@2.6.4
+# One resolution pass for the whole set. Installing these one at a time made npm
+# re-resolve and re-audit the entire ~580 package tree seven times over, which is
+# where most of this job's runtime went. mocha is a devDependency and npm scripts
+# put node_modules/.bin on PATH, so it no longer needs a separate global install.
+npm i \
+  nyc@15.1.0 \
+  mocha@^9.2.2 \
+  jsbn@1.1.0 \
+  lru-cache@5.1.1 \
+  moment-timezone@0.3.1 \
+  muk@0.5.3 \
+  async@2.6.4
 
 sudo touch /etc/firewalla-release
 sudo bash -c 'cat <<EOF > /etc/firewalla-release
@@ -31,5 +36,4 @@ mkdir -p ${HOME}/ovpns
 mkdir -p ${HOME}/logs
 mkdir -p ./coverage
 echo "{}" > ${HOME}/.firewalla/license
-sudo apt-get install redis
-sudo apt-get install ipset
+sudo apt-get install -y redis ipset


### PR DESCRIPTION
## Why

The `webpack` workflow takes 20–35 minutes per run, but the work it exists to do is fast: the four webpack builds finish in about **1 second** combined, eslint takes 6s, and `npm run coverage` takes ~10s. Everything else is npm dependency installation.

Step timings from three recent successful runs:

| Step | Time |
|---|---|
| **`bash .webpack/prep-env.sh`** | **14–24 min** |
| `npm install -g eslint@8.57.1` | 1.8–3.8 min |
| `npm i -g yarn` | 1.3–7 min |
| `yarn add webpack webpack-cli` | 13–15 s |
| 4× webpack builds | ~1 s total |
| `npm run coverage` | ~10 s |

Inside `prep-env.sh`, from the log of [run 33832081632](https://github.com/firewalla/firewalla/actions/runs/33832081632):

```
npm i nyc@15.1.0            added 583 packages ... in 2m
npm i -g mocha@^9.2.2       added  80 packages ... in 57s
npm i jsbn@1.1.0            added   2 packages ... in 1m
npm i lru-cache@5.1.1       added   2 packages ... in 2m
npm i moment-timezone@0.3.1 up to date, audited 583 packages in 3m
npm i muk@0.5.3             up to date, audited 583 packages in 3m
npm i async@2.6.4           up to date, audited 583 packages in 3m
```

Every `npm i <pkg>` re-resolves and re-audits the entire tree, so the last three take three minutes each to install nothing.

## What changed

- **Batch the seven installs into one.** One resolution pass instead of seven. `mocha` is already a devDependency and npm scripts put `node_modules/.bin` on `PATH`, so its separate global install is dropped — `npm run coverage` (`nyc mocha`) resolves the local copy.
- **Cache `~/.npm` between runs.** There is no lockfile in this repo, so `setup-node`'s built-in `cache: npm` can't be used (it requires `package-lock.json` or `yarn.lock`); `actions/cache` keyed on `package.json` achieves the same thing.
- **Skip `npm i -g yarn` when yarn is already present.** It ships with the ubuntu runner image. This step alone varied from 76s to 7 minutes across runs.
- **Bump `actions/checkout` and `actions/setup-node` from v2 to v4.** v2 runs on a deprecated Node runtime and warns on every run.
- Two small robustness fixes in `prep-env.sh`: the `/home/pi` symlink is now idempotent (`ln -sfn`, it fails on any re-run today), and redis + ipset install in one non-interactive `apt-get install -y` transaction.

Nothing about what the job actually builds, lints, or tests changes.

## Expected effect

Roughly **30 minutes → 5 minutes**, with the npm cache warm. Worth watching the first run on this PR, since it populates the cache rather than reading it.

## Follow-ups not included here

- No lockfile exists, so builds aren't reproducible and `npm ci` isn't available. Committing `package-lock.json` would enable `npm ci` plus `setup-node`'s native caching and cut install time further.
- `eslint` and `webpack-cli` are still installed globally per run; they could become devDependencies invoked through `npx`.
- Node 16 / npm 8 use a slower resolver than current npm, and produce `EBADENGINE` warnings against several dependencies.

https://claude.ai/code/session_012bKwLkR7gU1jL9GEL3cVmH