### PR TITLE
Close CBC padding oracle in unauthenticated encrypted-message API

### DIFF
--- a/api/lib/Encryption.js
+++ b/api/lib/Encryption.js
@@ -56,9 +56,11 @@ module.exports = class {
       }
     }
 
-    // decryptRequest parses the { iv, message } envelope once and returns usedIv;
-    // a request that carried an iv gets its reply mirrored with a fresh iv.
-    cloudWrapper.getCloud().decryptRequest(gid, message).then(({ decrypted: decryptedMessage, scheme }) => {
+    // decryptRequest parses the { iv, message } envelope once and reports the
+    // request scheme so the reply mirrors it. enforceGcmPolicy applies the
+    // anti-downgrade rule on this unauthenticated path: once a group has made a
+    // successful GCM request, CBC/legacy requests for it are rejected.
+    cloudWrapper.getCloud().decryptRequest(gid, message, { enforceGcmPolicy: true }).then(({ decrypted: decryptedMessage, scheme }) => {
       req.reqScheme = scheme;
       decryptedMessage.mtype = decryptedMessage.message.mtype;
       req.body = decryptedMessage;
@@ -66,11 +68,11 @@ module.exports = class {
       log.debug(req.id, 'Message decrypted')
       next();
     }).catch((err) => {
-      if(err && err.message === "decrypt_error") {
-        res.status(412).json({"error" : err});
-      } else {
-        res.status(400).json({"error" : err});
-      }
+      // All decrypt/parse failures must be externally indistinguishable — a
+      // status or body that varies with padding validity is a CBC padding
+      // oracle. Log details locally, return one uniform error.
+      log.error('Failed to decrypt request:', err && err.message);
+      res.status(412).json({"error" : "decrypt_error"});
     });
   }
 
@@ -88,9 +90,11 @@ module.exports = class {
       return;
     }
 
-    // Mirror the request scheme (gcm / cbc-iv / legacy) on the reply. Streaming
-    // stays on the legacy zero IV for now (its SSE frame carries no envelope).
-    const scheme = streaming ? 'legacy' : (req.reqScheme || 'legacy');
+    // Mirror the request scheme (gcm / cbc-iv / legacy) on the reply, streaming
+    // included: a client that sent a GCM request gets GCM SSE frames (the data
+    // field carries the JSON envelope; legacy frames were bare base64, which
+    // never starts with '{', so clients can tell them apart).
+    const scheme = req.reqScheme || 'legacy';
 
     // log.info('Response Data:', JSON.parse(body));
     const time = process.hrtime();

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -971,9 +971,18 @@ let legoEptCloud = class {
           }
           const scheme = this._schemeOf(env);
           if (opts.enforceGcmPolicy && scheme !== 'gcm' && await this.isGcmMigrated(gid)) {
-            log.error(`Rejecting ${scheme} request for GCM-migrated group ${gid}`);
-            reject(new Error("decrypt_error"));
-            return;
+            // gcm_downgrade_protection gates enforcement: off (default) is
+            // monitor-only — log the would-be rejection but accept the request,
+            // so mixed groups (an updated GCM app alongside an older CBC-only
+            // app) keep working while the fleet migrates. Turn the feature on
+            // to enforce and actually reject the downgrade.
+            if (config.isFeatureOn("gcm_downgrade_protection")) {
+              log.error(`Rejecting ${scheme} request for GCM-migrated group ${gid}`);
+              reject(new Error("decrypt_error"));
+              return;
+            } else {
+              log.warn(`Monitor: ${scheme} request for GCM-migrated group ${gid} would be rejected if gcm_downgrade_protection were enforced`);
+            }
           }
           let decrypted;
           try {

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -58,6 +58,10 @@ const notificationResendKey = "notification:resend";
 const notificationResendDuration = fConfig.timing['notification.resend.duration'] || 86400
 const notificationResendMaxCount = fConfig.timing['notification.resend.maxcount'] || 50
 
+// pre-decryption cap on unauthenticated encrypted-message input (chars of
+// base64); the API body parser allows 5mb, this bounds crypto/parse work.
+const MAX_ENCRYPTED_MSG_LEN = 5 * 1024 * 1024;
+
 function getUserHome() {
   return process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
 }
@@ -902,34 +906,97 @@ let legoEptCloud = class {
     }
   }
 
+  // Whether this group has ever completed a successful GCM request on the
+  // unauthenticated API path. Once true, unauthenticated CBC envelopes for the
+  // group are rejected (trust-on-first-use anti-downgrade). Cached in memory,
+  // persisted in redis so it survives restarts. Clear with:
+  //   redis-cli hdel sys:ept:gcmGids <gid>
+  async isGcmMigrated(gid) {
+    if (this._gcmGids && this._gcmGids[gid]) return true;
+    const ts = await rclient.hgetAsync(Constants.REDIS_KEY_EPT_GCM_GIDS, gid).catch(() => null);
+    if (ts) {
+      this._gcmGids = this._gcmGids || {};
+      this._gcmGids[gid] = true;
+      return true;
+    }
+    return false;
+  }
+
+  markGcmMigrated(gid) {
+    this._gcmGids = this._gcmGids || {};
+    if (this._gcmGids[gid]) return;
+    this._gcmGids[gid] = true;
+    log.info(`Group ${gid} migrated to GCM, unauthenticated CBC requests will be rejected for it`);
+    rclient.hsetAsync(Constants.REDIS_KEY_EPT_GCM_GIDS, gid, Math.floor(Date.now() / 1000))
+      .catch((err) => log.error("Failed to persist GCM migration flag", err.message));
+  }
+
   // Request decryption for the netbot req/response path. Parses the envelope
-  // once and resolves { decrypted, usedIv } — usedIv tells the caller whether
-  // the request carried an IV so the reply can mirror it (avoids re-parsing).
-  decryptRequest(gid, msg) {
+  // once and resolves { decrypted, scheme } — scheme tells the caller how the
+  // request was encrypted so the reply can mirror it (avoids re-parsing).
+  //
+  // Every failure after key lookup rejects with the same opaque "decrypt_error":
+  // bad envelope, bad padding, GCM auth failure, oversized input and
+  // post-decrypt JSON parse failure are externally indistinguishable, so the
+  // endpoint cannot be used as a CBC padding oracle (invalid padding vs valid
+  // padding + garbage plaintext must not be observable). Details are logged
+  // locally only.
+  //
+  // opts.enforceGcmPolicy: set by the unauthenticated local API path. Applies
+  // the trust-on-first-use downgrade protection: after the first successful GCM
+  // request for a gid, CBC/legacy envelopes for that gid are rejected. Paths
+  // with an authenticated transport (e.g. Guardian over TLS to MSP) leave it
+  // off, since other legitimate clients of the same group may still be on CBC.
+  decryptRequest(gid, msg, opts = {}) {
     return new Promise((resolve, reject) => {
-      this.getKey(gid, false, (err, key) => {
-        if (key == null) {
-          reject(err || new Error("key not found, invalid group?"));
-          return;
-        }
-        const env = this._parseEnvelope(msg);
-        if (env.invalid) {
-          reject(new Error("decrypt_error"));
-          return;
-        }
-        let decrypted;
+      this.getKey(gid, false, async (err, key) => {
         try {
-          decrypted = this._decryptWithEnvelope(env, key);
+          if (key == null) {
+            reject(err || new Error("key not found, invalid group?"));
+            return;
+          }
+          // pre-decryption resource limit: bound work done on unauthenticated
+          // input before any crypto/parse. The API body parser allows 5mb.
+          const approxLen = typeof msg === 'string' ? msg.length :
+            (msg && typeof msg.message === 'string' ? msg.message.length : 0);
+          if (approxLen > MAX_ENCRYPTED_MSG_LEN) {
+            log.error(`Rejecting oversized encrypted message (${approxLen} chars) for group ${gid}`);
+            reject(new Error("decrypt_error"));
+            return;
+          }
+          const env = this._parseEnvelope(msg);
+          if (env.invalid) {
+            reject(new Error("decrypt_error"));
+            return;
+          }
+          const scheme = this._schemeOf(env);
+          if (opts.enforceGcmPolicy && scheme !== 'gcm' && await this.isGcmMigrated(gid)) {
+            log.error(`Rejecting ${scheme} request for GCM-migrated group ${gid}`);
+            reject(new Error("decrypt_error"));
+            return;
+          }
+          let decrypted;
+          try {
+            decrypted = this._decryptWithEnvelope(env, key);
+          } catch (e) {
+            log.error("Failed to decrypt message, err:", e.message);
+            reject(new Error("decrypt_error"));
+            return;
+          }
+          const msgJson = this._parseJsonSafe(decrypted);
+          if (msgJson == null) {
+            // decrypted but not JSON: externally identical to a decrypt failure
+            log.error("Decrypted message is not valid JSON");
+            reject(new Error("decrypt_error"));
+            return;
+          }
+          if (opts.enforceGcmPolicy && scheme === 'gcm')
+            this.markGcmMigrated(gid);
+          resolve({ decrypted: msgJson, scheme });
         } catch (e) {
-          log.error("Failed to decrypt message, err:", e);
+          log.error("Unexpected error decrypting request", e.message);
           reject(new Error("decrypt_error"));
-          return;
         }
-        const msgJson = this._parseJsonSafe(decrypted);
-        if (msgJson != null)
-          resolve({ decrypted: msgJson, scheme: this._schemeOf(env) });
-        else
-          reject(new Error("Malformed JSON"));
       });
     });
   }

--- a/encipher/lib/encipherio.js
+++ b/encipher/lib/encipherio.js
@@ -922,13 +922,16 @@ let legoEptCloud = class {
     return false;
   }
 
-  markGcmMigrated(gid) {
+  // Persist-then-cache: the in-memory flag is only set after the redis write
+  // succeeds, so a persistence failure is visible to the caller (throws) and a
+  // later call retries the write instead of silently running memory-only,
+  // which would lose the migration state on restart.
+  async markGcmMigrated(gid) {
     this._gcmGids = this._gcmGids || {};
     if (this._gcmGids[gid]) return;
+    await rclient.hsetAsync(Constants.REDIS_KEY_EPT_GCM_GIDS, gid, Math.floor(Date.now() / 1000));
     this._gcmGids[gid] = true;
     log.info(`Group ${gid} migrated to GCM, unauthenticated CBC requests will be rejected for it`);
-    rclient.hsetAsync(Constants.REDIS_KEY_EPT_GCM_GIDS, gid, Math.floor(Date.now() / 1000))
-      .catch((err) => log.error("Failed to persist GCM migration flag", err.message));
   }
 
   // Request decryption for the netbot req/response path. Parses the envelope
@@ -969,6 +972,19 @@ let legoEptCloud = class {
             reject(new Error("decrypt_error"));
             return;
           }
+          // bound every accepted envelope field before any crypto work. The
+          // string-input length check above cannot see inside an already-parsed
+          // object envelope, whose individual fields could be oversized while
+          // the ciphertext alone stays under the cap. (iv is 24 chars base64
+          // for CBC, 16 for a GCM nonce; tag 24; alg is "gcm".)
+          if (typeof env.ct !== 'string' || env.ct.length > MAX_ENCRYPTED_MSG_LEN ||
+            (env.iv != null && !Buffer.isBuffer(env.iv) && (typeof env.iv !== 'string' || env.iv.length > 64)) ||
+            (env.tag != null && (typeof env.tag !== 'string' || env.tag.length > 64)) ||
+            (env.alg != null && (typeof env.alg !== 'string' || env.alg.length > 16))) {
+            log.error(`Rejecting envelope with out-of-bounds field for group ${gid}`);
+            reject(new Error("decrypt_error"));
+            return;
+          }
           const scheme = this._schemeOf(env);
           if (opts.enforceGcmPolicy && scheme !== 'gcm' && await this.isGcmMigrated(gid)) {
             // gcm_downgrade_protection gates enforcement: off (default) is
@@ -999,8 +1015,22 @@ let legoEptCloud = class {
             reject(new Error("decrypt_error"));
             return;
           }
-          if (opts.enforceGcmPolicy && scheme === 'gcm')
-            this.markGcmMigrated(gid);
+          if (opts.enforceGcmPolicy && scheme === 'gcm') {
+            try {
+              await this.markGcmMigrated(gid);
+            } catch (e) {
+              log.error("Failed to persist GCM migration flag for group", gid, e.message);
+              if (config.isFeatureOn("gcm_downgrade_protection")) {
+                // fail closed under enforcement: without durable migration
+                // state, accepting this request would let a restart re-enable
+                // the CBC downgrade window.
+                reject(new Error("decrypt_error"));
+                return;
+              }
+              // monitor mode: accept the request; the next GCM request retries
+              // the write since the in-memory flag was not set.
+            }
+          }
           resolve({ decrypted: msgJson, scheme });
         } catch (e) {
           log.error("Unexpected error decrypting request", e.message);

--- a/net2/Constants.js
+++ b/net2/Constants.js
@@ -51,6 +51,7 @@ module.exports = {
   REDIS_KEY_EID_REVOKE_SET: "sys:ept:members:revoked",
   REDIS_KEY_EPT_MEMBER_EMAILS: "sys:ept:memberEmails",
   REDIS_KEY_EPT_PAIRED_PENDING: "sys:ept:pairedPending",
+  REDIS_KEY_EPT_GCM_GIDS: "sys:ept:gcmGids",
   REDIS_KEY_GROUP_NAME: "groupName",
   REDIS_KEY_DDNS_UPDATE: "ddns:update",
   REDIS_KEY_CPU_USAGE: "cpu_usage_records",

--- a/net2/config.json
+++ b/net2/config.json
@@ -1168,6 +1168,7 @@
     "digitalfence": false,
     "compress_flows": false,
     "rekey": false,
+    "gcm_downgrade_protection": false,
     "pcap_zeek": true,
     "pcap_suricata": false,
     "local_flow": false,

--- a/test/test_encipher_oracle.js
+++ b/test/test_encipher_oracle.js
@@ -1,0 +1,134 @@
+/*    Copyright 2026 Firewalla Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+'use strict';
+
+// Regression tests for the CBC padding oracle in the unauthenticated
+// encrypted-message API (firewalla/firecommit#9400):
+//  - every decrypt/parse failure in decryptRequest must reject with the same
+//    opaque "decrypt_error" (bad padding must be indistinguishable from valid
+//    padding + non-JSON plaintext),
+//  - once a group has made a successful GCM request on the enforcing path,
+//    CBC/legacy requests for it are rejected (no client-controlled downgrade),
+//  - oversized input is rejected before any crypto work.
+
+const chai = require('chai');
+const expect = chai.expect;
+const crypto = require('crypto');
+
+const EptCloud = require('../encipher');
+
+describe('encipher decryptRequest uniform errors and GCM policy', function () {
+  this.timeout(5000);
+
+  let ept;
+  const key = crypto.randomBytes(24).toString('base64');
+  const gid = 'oracle-test-gid-' + crypto.randomBytes(4).toString('hex');
+  const validMessage = JSON.stringify({ message: { mtype: 'msg', obj: { id: 1 } } });
+
+  const rejectionOf = p => p.then(() => null, err => err);
+
+  before(() => {
+    ept = new EptCloud('test-oracle-unit');
+    ept.gid = gid; // GCM AAD source
+    ept.getKey = (g, refresh, cb) => cb(null, key);
+  });
+
+  after(async () => {
+    // remove the persisted migration flag so reruns and other tests start clean
+    const rclient = require('../util/redis_manager.js').getRedisClient();
+    const Constants = require('../net2/Constants.js');
+    await rclient.hdelAsync(Constants.REDIS_KEY_EPT_GCM_GIDS, gid).catch(() => undefined);
+  });
+
+  describe('uniform decrypt_error (padding-oracle regression)', () => {
+    it('accepts a valid CBC request', async () => {
+      const { decrypted, scheme } = await ept.decryptRequest(gid, ept.encrypt(validMessage, key, crypto.randomBytes(16)));
+      expect(decrypted.message.mtype).to.equal('msg');
+      expect(scheme).to.equal('cbc-iv');
+    });
+
+    it('rejects invalid padding with decrypt_error', async () => {
+      const env = JSON.parse(ept.encrypt(validMessage, key, crypto.randomBytes(16)));
+      const ct = Buffer.from(env.message, 'base64');
+      ct[ct.length - 1] ^= 1; // corrupt final block -> padding check fails w.h.p.
+      env.message = ct.toString('base64');
+      const err = await rejectionOf(ept.decryptRequest(gid, JSON.stringify(env)));
+      expect(err).to.be.an('error');
+      expect(err.message).to.equal('decrypt_error');
+    });
+
+    it('rejects valid padding + non-JSON plaintext with the SAME decrypt_error', async () => {
+      // decrypts cleanly but the plaintext is not JSON; before the fix this
+      // rejected "Malformed JSON" -> HTTP 400 vs 412, the padding oracle.
+      const err = await rejectionOf(ept.decryptRequest(gid, ept.encrypt('not json', key, crypto.randomBytes(16))));
+      expect(err).to.be.an('error');
+      expect(err.message).to.equal('decrypt_error');
+    });
+
+    it('rejects an invalid envelope with the same decrypt_error', async () => {
+      const err = await rejectionOf(ept.decryptRequest(gid, JSON.stringify({ iv: 'AA==' })));
+      expect(err.message).to.equal('decrypt_error');
+    });
+
+    it('rejects oversized input before decryption with the same decrypt_error', async () => {
+      const big = 'A'.repeat(5 * 1024 * 1024 + 1);
+      expect((await rejectionOf(ept.decryptRequest(gid, big))).message).to.equal('decrypt_error');
+      expect((await rejectionOf(ept.decryptRequest(gid, { message: big }))).message).to.equal('decrypt_error');
+    });
+  });
+
+  describe('GCM anti-downgrade policy', () => {
+    it('CBC is accepted on the enforcing path before the group migrates', async () => {
+      expect(await ept.isGcmMigrated(gid)).to.equal(false);
+      const { scheme } = await ept.decryptRequest(gid, ept.encrypt(validMessage, key, crypto.randomBytes(16)), { enforceGcmPolicy: true });
+      expect(scheme).to.equal('cbc-iv');
+    });
+
+    it('a successful GCM request marks the group migrated', async () => {
+      const { scheme } = await ept.decryptRequest(gid, ept._encryptGcm(validMessage, key), { enforceGcmPolicy: true });
+      expect(scheme).to.equal('gcm');
+      expect(await ept.isGcmMigrated(gid)).to.equal(true);
+    });
+
+    it('CBC and legacy requests are rejected for a migrated group on the enforcing path', async () => {
+      const cbc = ept.encrypt(validMessage, key, crypto.randomBytes(16));
+      expect((await rejectionOf(ept.decryptRequest(gid, cbc, { enforceGcmPolicy: true }))).message).to.equal('decrypt_error');
+      const legacy = ept.encrypt(validMessage, key); // zero-IV bare base64
+      expect((await rejectionOf(ept.decryptRequest(gid, legacy, { enforceGcmPolicy: true }))).message).to.equal('decrypt_error');
+    });
+
+    it('GCM requests still work for a migrated group', async () => {
+      const { decrypted, scheme } = await ept.decryptRequest(gid, ept._encryptGcm(validMessage, key), { enforceGcmPolicy: true });
+      expect(scheme).to.equal('gcm');
+      expect(decrypted.message.mtype).to.equal('msg');
+    });
+
+    it('non-enforcing paths (authenticated transports) still accept CBC for a migrated group', async () => {
+      const { scheme } = await ept.decryptRequest(gid, ept.encrypt(validMessage, key, crypto.randomBytes(16)));
+      expect(scheme).to.equal('cbc-iv');
+    });
+
+    it('a failed GCM request does not mark an unmigrated group', async () => {
+      const gid2 = gid + '-unmigrated';
+      const ept2 = Object.create(ept);
+      ept2.gid = gid2;
+      ept2._gcmGids = {};
+      const o = JSON.parse(ept._encryptGcm(validMessage, key)); // AAD = gid, not gid2
+      const err = await rejectionOf(ept2.decryptRequest(gid2, JSON.stringify(o), { enforceGcmPolicy: true }));
+      expect(err.message).to.equal('decrypt_error');
+      expect(ept2._gcmGids[gid2]).to.equal(undefined);
+    });
+  });
+});

--- a/test/test_encipher_oracle.js
+++ b/test/test_encipher_oracle.js
@@ -134,14 +134,64 @@ describe('encipher decryptRequest uniform errors and GCM policy', function () {
     });
 
     it('a failed GCM request does not mark an unmigrated group', async () => {
+      // a genuinely separate instance and group, never migrated
       const gid2 = gid + '-unmigrated';
-      const ept2 = Object.create(ept);
+      const ept2 = new EptCloud('test-oracle-unit-2');
       ept2.gid = gid2;
-      ept2._gcmGids = {};
-      const o = JSON.parse(ept._encryptGcm(validMessage, key)); // AAD = gid, not gid2
+      ept2.getKey = (g, refresh, cb) => cb(null, key);
+      const o = JSON.parse(ept._encryptGcm(validMessage, key)); // AAD = gid, not gid2 -> auth fails
       const err = await rejectionOf(ept2.decryptRequest(gid2, JSON.stringify(o), { enforceGcmPolicy: true }));
       expect(err.message).to.equal('decrypt_error');
-      expect(ept2._gcmGids[gid2]).to.equal(undefined);
+      expect(ept2._gcmGids && ept2._gcmGids[gid2]).to.not.be.ok;
+      expect(await ept2.isGcmMigrated(gid2)).to.equal(false);
+    });
+  });
+
+  describe('envelope field bounds', () => {
+    it('rejects an object envelope with an oversized iv even when the ciphertext is small', async () => {
+      const env = JSON.parse(ept.encrypt(validMessage, key, crypto.randomBytes(16)));
+      env.iv = 'A'.repeat(100000);
+      const err = await rejectionOf(ept.decryptRequest(gid, env)); // already-parsed object input
+      expect(err.message).to.equal('decrypt_error');
+    });
+
+    it('rejects an oversized tag / alg field with the same decrypt_error', async () => {
+      const env = JSON.parse(ept._encryptGcm(validMessage, key));
+      const bigTag = { ...env, tag: 'A'.repeat(100000) };
+      expect((await rejectionOf(ept.decryptRequest(gid, bigTag))).message).to.equal('decrypt_error');
+      const bigAlg = { ...env, alg: 'g'.repeat(1000) };
+      expect((await rejectionOf(ept.decryptRequest(gid, bigAlg))).message).to.equal('decrypt_error');
+    });
+
+    it('rejects a non-string ciphertext field', async () => {
+      expect((await rejectionOf(ept.decryptRequest(gid, { message: 12345 }))).message).to.equal('decrypt_error');
+    });
+  });
+
+  describe('migration persistence failure handling', () => {
+    const failingEpt = () => {
+      const e = new EptCloud('test-oracle-unit-persist-' + crypto.randomBytes(3).toString('hex'));
+      e.gid = gid;
+      e.getKey = (g, refresh, cb) => cb(null, key);
+      e.markGcmMigrated = async () => { throw new Error('redis down'); };
+      return e;
+    };
+
+    it('monitor mode (default): a GCM request still succeeds when persistence fails', async () => {
+      const { scheme } = await failingEpt().decryptRequest(gid, ept._encryptGcm(validMessage, key), { enforceGcmPolicy: true });
+      expect(scheme).to.equal('gcm');
+    });
+
+    it('enforcement on: a GCM request fails closed when persistence fails', async () => {
+      const fwConfig = require('../net2/config.js');
+      const origIsFeatureOn = fwConfig.isFeatureOn;
+      fwConfig.isFeatureOn = (name, dflt) => name === 'gcm_downgrade_protection' ? true : origIsFeatureOn(name, dflt);
+      try {
+        const err = await rejectionOf(failingEpt().decryptRequest(gid, ept._encryptGcm(validMessage, key), { enforceGcmPolicy: true }));
+        expect(err.message).to.equal('decrypt_error');
+      } finally {
+        fwConfig.isFeatureOn = origIsFeatureOn;
+      }
     });
   });
 });

--- a/test/test_encipher_oracle.js
+++ b/test/test_encipher_oracle.js
@@ -102,11 +102,24 @@ describe('encipher decryptRequest uniform errors and GCM policy', function () {
       expect(await ept.isGcmMigrated(gid)).to.equal(true);
     });
 
-    it('CBC and legacy requests are rejected for a migrated group on the enforcing path', async () => {
-      const cbc = ept.encrypt(validMessage, key, crypto.randomBytes(16));
-      expect((await rejectionOf(ept.decryptRequest(gid, cbc, { enforceGcmPolicy: true }))).message).to.equal('decrypt_error');
-      const legacy = ept.encrypt(validMessage, key); // zero-IV bare base64
-      expect((await rejectionOf(ept.decryptRequest(gid, legacy, { enforceGcmPolicy: true }))).message).to.equal('decrypt_error');
+    it('monitor-only by default: CBC for a migrated group is logged but still accepted', async () => {
+      // gcm_downgrade_protection defaults to off -> monitor mode
+      const { scheme } = await ept.decryptRequest(gid, ept.encrypt(validMessage, key, crypto.randomBytes(16)), { enforceGcmPolicy: true });
+      expect(scheme).to.equal('cbc-iv');
+    });
+
+    it('CBC and legacy requests are rejected for a migrated group when gcm_downgrade_protection is on', async () => {
+      const fwConfig = require('../net2/config.js');
+      const origIsFeatureOn = fwConfig.isFeatureOn;
+      fwConfig.isFeatureOn = (name, dflt) => name === 'gcm_downgrade_protection' ? true : origIsFeatureOn(name, dflt);
+      try {
+        const cbc = ept.encrypt(validMessage, key, crypto.randomBytes(16));
+        expect((await rejectionOf(ept.decryptRequest(gid, cbc, { enforceGcmPolicy: true }))).message).to.equal('decrypt_error');
+        const legacy = ept.encrypt(validMessage, key); // zero-IV bare base64
+        expect((await rejectionOf(ept.decryptRequest(gid, legacy, { enforceGcmPolicy: true }))).message).to.equal('decrypt_error');
+      } finally {
+        fwConfig.isFeatureOn = origIsFeatureOn;
+      }
     });
 
     it('GCM requests still work for a migrated group', async () => {


### PR DESCRIPTION
Fixes firewalla/firecommit#9400.

The external `/v1/encipher/message/:gid` endpoint distinguished CBC padding failures (412) from valid-padding-but-invalid-JSON (400), giving an unauthenticated client a padding oracle against the group key's CBC envelopes.

### Changes
- **Uniform errors**: every failure in `decryptRequest` (bad envelope, bad padding, GCM auth failure, oversized input, post-decrypt JSON parse failure) rejects with the same opaque `decrypt_error`; the middleware returns one uniform `412 {error: "decrypt_error"}` with details logged locally only. Guardian's web-message path picks up the same uniform behavior automatically.
- **Anti-downgrade (TOFU), gated by the `gcm_downgrade_protection` feature (default off = monitor-only)**: on the unauthenticated local API path, a group's first successful GCM request marks it migrated (`sys:ept:gcmGids`, in-memory + redis). With the feature **off** (default), a CBC/legacy request for a migrated group is logged as a would-be rejection but still accepted — safe for mixed groups during migration. With the feature **on**, it is rejected. Roll back a group with `redis-cli hdel sys:ept:gcmGids <gid>`. The Guardian/MSP path does not enforce this since other legitimate clients of the same group may still use CBC.
- **Pre-decryption limit**: 5MB cap on encrypted input (matches the body-parser limit) before any crypto/parse work.
- **Streaming**: SSE frames now mirror the request scheme instead of forcing legacy zero-IV CBC; a GCM client gets GCM envelope frames (legacy frames are bare base64 and never start with `{`, so clients can distinguish).

### Compatibility
- CBC-only app versions keep working: enforcement only starts after the group's first successful GCM request.
- Mixed groups (one updated GCM app + one old CBC app on the same gid): unaffected by default (monitor-only). Once `gcm_downgrade_protection` is turned on, the old app is rejected after the new one's first GCM request — the intended downgrade protection; the redis flag is the escape hatch.

### Validation
- `node --check` on all touched files.
- Self-contained harness (based on the issue's verification script, extended with rclient/Constants stubs) run against this checkout: uniform 412 + identical bodies for bad-padding vs valid-padding/bad-JSON fixtures, valid CBC & GCM accepted pre-migration, CBC/legacy rejected + GCM accepted post-migration, flag persisted, oversize rejected, Guardian path still accepts CBC, streaming mirrors GCM.
- Regression tests added in `test/test_encipher_oracle.js` (mocha; needs a box/dev env with node_modules + redis).
