### PR TITLE
refresh device hosts file on address and name changes instead of waiting for a scan

### DIFF
--- a/hook/DeviceHook.js
+++ b/hook/DeviceHook.js
@@ -38,6 +38,7 @@ const Samba = require('../extension/samba/samba.js');
 const samba = new Samba();
 
 const HostManager = require('../net2/HostManager.js');
+const Host = require('../net2/Host.js');
 
 const sysManager = require('../net2/SysManager.js');
 
@@ -514,6 +515,17 @@ class DeviceHook extends Hook {
           // Another issue in this scenario is that this could mess up flow-device mappings
           // which could only be fix once flow is associated with mac address
           await hostTool.removeDupIPv4FromMacEntry(event.oldMac, host.ipv4Addr, host.mac);
+          // the previous owner just lost this IPv4, drop its stale record in the hosts file
+          // instead of waiting for the next Scan:Done. Also clear the in-memory copy, otherwise
+          // it will be persisted again on the next update and unlinked on destroy
+          const oldHost = Host.getInstance(event.oldMac);
+          if (oldHost) {
+            if (oldHost.o.ipv4Addr === host.ipv4Addr)
+              delete oldHost.o.ipv4Addr;
+            if (oldHost.o.ipv4 === host.ipv4Addr)
+              delete oldHost.o.ipv4;
+            oldHost.scheduleUpdateHostData();
+          }
 
           const hostManager = new HostManager();
           const h = await hostManager.getHostAsync(host.mac)

--- a/net2/Host.js
+++ b/net2/Host.js
@@ -102,6 +102,10 @@ class Host extends Monitorable {
 
         messageBus.subscribeOnce(this.constructor.getUpdateCh(), this.getGUID(), this.onUpdate.bind(this))
 
+        // derive bname/localDomain/userLocalDomain, a host created from scratch has none of them
+        // yet. The publish is picked up by the subscription above, which schedules the hosts file
+        await this.update(this.o, false, true)
+
         await this.applyPolicy()
       })().catch(err => {
         log.error(`Error initializing Host ${this.o.mac}`, err);
@@ -738,6 +742,9 @@ class Host extends Monitorable {
 
       if (this.invalidateHostsFileTask)
         clearTimeout(this.invalidateHostsFileTask);
+      // otherwise a pending task will re-add ipset entries and re-create the hosts file below
+      if (this.updateHostDataTask)
+        clearTimeout(this.updateHostDataTask);
       const hostsFile = Host.getHostsFilePath(this.o.mac);
       await fs.unlinkAsync(hostsFile).then(() => {
         dnsmasq.scheduleReloadDNSService();
@@ -801,6 +808,12 @@ class Host extends Monitorable {
         if (ops.length)
           await Ipset.restore(ops, true);
 
+        // hosts file is derived from the same host object as the ipsets above.
+        // own catch + placed before identifyDevice() so neither can skip the other
+        await this.updateHostsFileIfChanged().catch((err) => {
+          log.error(`Failed to update hosts file of ${this.o.mac}`, err.message);
+        });
+
         await this.identifyDevice(false)
       } catch (err) {
         log.error('Error update host data', err)
@@ -808,87 +821,129 @@ class Host extends Monitorable {
     }, 3000);
   }
 
+  // normalized key of the IPv6 addresses that actually affect the hosts file,
+  // i.e. valid and not link-local, see the entry generation in updateHostsFile()
+  static hostsFileV6Key(v6) {
+    if (_.isString(v6)) {
+      try { v6 = JSON.parse(v6) } catch (err) { return "" }
+    }
+    if (!_.isArray(v6))
+      return "";
+    return v6.filter((ip) => {
+      try {
+        const addr6 = new Address6(ip);
+        // isValid() only exists in ip-address 6.x, newer versions throw in the constructor instead
+        if (_.isFunction(addr6.isValid) && !addr6.isValid())
+          return false;
+        return !addr6.isLinkLocal();
+      } catch (err) {
+        return false;
+      }
+    }).sort().join(",");
+  }
+
+  // refresh the hosts file only if one of the fields it is rendered from changed,
+  // this merely saves a couple of redis reads, updateHostsFile() dedups the write itself
+  async updateHostsFileIfChanged() {
+    if (!fc.isFeatureOn('local_domain'))
+      return;
+    const key = [
+      this.o.ipv4Addr,
+      Host.hostsFileV6Key(this.ipv6Addr),
+      this.o.localDomain,
+      this.o.userLocalDomain
+    ].join("|");
+    if (this._hostsFileKey === key)
+      return;
+    await this.updateHostsFile();
+    // only record on success so a failed write is retried on the next update
+    this._hostsFileKey = key;
+  }
+
   async updateHostsFile() {
-    const macEntry = await hostTool.getMACEntry(this.o.mac);
-    // update hosts file in dnsmasq
-    const hostsFile = Host.getHostsFilePath(this.o.mac);
-    const lastActiveTimestamp = Number((macEntry && macEntry.lastActiveTimestamp) || 0);
-    if (!macEntry || Date.now() / 1000 - lastActiveTimestamp > 86400 * 3 * 1000) {
-      // remove hosts file if it is not active in the last 3 days or it is already removed from host:mac:*
-      if (this._lastHostfileEntries !== null) {
-        await fs.unlinkAsync(hostsFile).catch((err) => { });
-        dnsmasq.scheduleReloadDNSService();
-        this._lastHostfileEntries = null;
+    // serialize per device, _lastHostfileEntries is read and written across awaits below
+    await lock.acquire(`HOSTSFILE_${this.o.mac}`, async () => {
+      const macEntry = await hostTool.getMACEntry(this.o.mac);
+      // update hosts file in dnsmasq
+      const hostsFile = Host.getHostsFilePath(this.o.mac);
+      const lastActiveTimestamp = Number((macEntry && macEntry.lastActiveTimestamp) || 0);
+      if (!macEntry || Date.now() / 1000 - lastActiveTimestamp > 86400 * 3 * 1000) {
+        // remove hosts file if it is not active in the last 3 days or it is already removed from host:mac:*
+        if (this._lastHostfileEntries !== null) {
+          await fs.unlinkAsync(hostsFile).catch((err) => { });
+          dnsmasq.scheduleReloadDNSService();
+          this._lastHostfileEntries = null;
+        }
+        return;
       }
-      return;
-    }
-    const ipv4Addr = macEntry && macEntry.ipv4Addr;
-    const suffix = await rclient.getAsync(Constants.REDIS_KEY_LOCAL_DOMAIN_SUFFIX) || "lan";
-    const localDomain = macEntry.localDomain || "";
-    const userLocalDomain = macEntry.userLocalDomain || "";
-    if (!ipv4Addr) {
-      if (this._lastHostfileEntries !== null) {
-        await fs.unlinkAsync(hostsFile).catch((err) => { });
-        dnsmasq.scheduleReloadDNSService();
-        this._lastHostfileEntries = null;
+      const ipv4Addr = macEntry && macEntry.ipv4Addr;
+      const suffix = await rclient.getAsync(Constants.REDIS_KEY_LOCAL_DOMAIN_SUFFIX) || "lan";
+      const localDomain = macEntry.localDomain || "";
+      const userLocalDomain = macEntry.userLocalDomain || "";
+      if (!ipv4Addr) {
+        if (this._lastHostfileEntries !== null) {
+          await fs.unlinkAsync(hostsFile).catch((err) => { });
+          dnsmasq.scheduleReloadDNSService();
+          this._lastHostfileEntries = null;
+        }
+        return;
       }
-      return;
-    }
-    let ipv6Addr = null;
-    try {
-      ipv6Addr = macEntry && macEntry.ipv6Addr && JSON.parse(macEntry.ipv6Addr);
-    } catch (err) {}
-    const aliases = [userLocalDomain, localDomain].filter((d) => d.length !== 0).map(s => getCanonicalizedDomainname(s.replace(/\s+/g, "."))).filter((v, i, a) => {
-      return a.indexOf(v) === i;
-    })
-    const iface = sysManager.getInterfaceViaIP(ipv4Addr);
-    if (!iface) {
-      if (this._lastHostfileEntries !== null) {
-        await fs.unlinkAsync(hostsFile).catch((err) => { });
-        dnsmasq.scheduleReloadDNSService();
-        this._lastHostfileEntries = null;
+      let ipv6Addr = null;
+      try {
+        ipv6Addr = macEntry && macEntry.ipv6Addr && JSON.parse(macEntry.ipv6Addr);
+      } catch (err) {}
+      const aliases = [userLocalDomain, localDomain].filter((d) => d.length !== 0).map(s => getCanonicalizedDomainname(s.replace(/\s+/g, "."))).filter((v, i, a) => {
+        return a.indexOf(v) === i;
+      })
+      const iface = sysManager.getInterfaceViaIP(ipv4Addr);
+      if (!iface) {
+        if (this._lastHostfileEntries !== null) {
+          await fs.unlinkAsync(hostsFile).catch((err) => { });
+          dnsmasq.scheduleReloadDNSService();
+          this._lastHostfileEntries = null;
+        }
+        return;
       }
-      return;
-    }
-    const localDomains = sysManager.getInterfaces().flatMap((intf) => intf.localDomains || []);
-    const suffixes = _.uniq((iface.searchDomains || []).concat([suffix]).concat(localDomains).map(s => getCanonicalizedDomainname(s.replace(/\s+/g, "."))));
-    const entries = [];
-    for (const suffix of suffixes) {
-      for (const alias of aliases) {
-        const fqdn = `${alias}.${suffix}`;
-        if (new Address4(ipv4Addr).isValid())
-          entries.push(`${ipv4Addr} ${fqdn}`);
-        let ipv6Found = false;
-        if (_.isArray(ipv6Addr)) {
-          for (const addr of ipv6Addr) {
-            const addr6 = new Address6(addr);
-            if (addr6.isValid() && !addr6.isLinkLocal()) {
-              ipv6Found = true;
-              entries.push(`${addr} ${fqdn}`);
+      const localDomains = sysManager.getInterfaces().flatMap((intf) => intf.localDomains || []);
+      const suffixes = _.uniq((iface.searchDomains || []).concat([suffix]).concat(localDomains).map(s => getCanonicalizedDomainname(s.replace(/\s+/g, "."))));
+      const entries = [];
+      for (const suffix of suffixes) {
+        for (const alias of aliases) {
+          const fqdn = `${alias}.${suffix}`;
+          if (new Address4(ipv4Addr).isValid())
+            entries.push(`${ipv4Addr} ${fqdn}`);
+          let ipv6Found = false;
+          if (_.isArray(ipv6Addr)) {
+            for (const addr of ipv6Addr) {
+              const addr6 = new Address6(addr);
+              if (addr6.isValid() && !addr6.isLinkLocal()) {
+                ipv6Found = true;
+                entries.push(`${addr} ${fqdn}`);
+              }
             }
           }
+          // add empty ipv6 address if no routable ipv6 address is available
+          if (!ipv6Found)
+            entries.push(`:: ${fqdn}`);
         }
-        // add empty ipv6 address if no routable ipv6 address is available
-        if (!ipv6Found)
-          entries.push(`:: ${fqdn}`);
       }
-    }
-    if (entries.length !== 0) {
-      if (this._lastHostfileEntries !== entries.sort().join("\n")) {
-        await dnsmasq.writeConfig(hostsFile, entries).catch((err) => {
-          log.error(`Failed to write hosts file ${hostsFile}`, err.message);
-        });
-        dnsmasq.scheduleReloadDNSService();
-        this._lastHostfileEntries = entries.sort().join("\n");
+      if (entries.length !== 0) {
+        if (this._lastHostfileEntries !== entries.sort().join("\n")) {
+          await dnsmasq.writeConfig(hostsFile, entries).catch((err) => {
+            log.error(`Failed to write hosts file ${hostsFile}`, err.message);
+          });
+          dnsmasq.scheduleReloadDNSService();
+          this._lastHostfileEntries = entries.sort().join("\n");
+        }
+      } else {
+        if (this._lastHostfileEntries !== null) {
+          await fs.unlinkAsync(hostsFile).catch((err) => { });
+          dnsmasq.scheduleReloadDNSService();
+          this._lastHostfileEntries = null;
+        }
       }
-    } else {
-      if (this._lastHostfileEntries !== null) {
-        await fs.unlinkAsync(hostsFile).catch((err) => { });
-        dnsmasq.scheduleReloadDNSService();
-        this._lastHostfileEntries = null;
-      }
-    }
-    this.scheduleInvalidateHostsFile();
+      this.scheduleInvalidateHostsFile();
+    });
   }
 
   scheduleInvalidateHostsFile() {

--- a/test/test_host.js
+++ b/test/test_host.js
@@ -21,6 +21,8 @@ let expect = chai.expect;
 const log = require('../net2/logger.js')(__filename)
 const Host = require('../net2/Host.js');
 const rclient = require('../util/redis_manager.js').getRedisClient();
+const fc = require('../net2/config.js');
+const Monitorable = require('../net2/Monitorable.js');
 
 describe('test _get24HoursTopDomains', function(){
   const testMac = 'AA:BB:CC:DD:EE:FF';
@@ -313,5 +315,111 @@ describe('test _get24HoursTopDomains', function(){
 
     // Cleanup
     await host.destroy();
+  });
+});
+
+describe('Host.hostsFileV6Key', function() {
+
+  it('should ignore anything that is not an address array', () => {
+    expect(Host.hostsFileV6Key(undefined)).to.equal('');
+    expect(Host.hostsFileV6Key(null)).to.equal('');
+    expect(Host.hostsFileV6Key({})).to.equal('');
+    expect(Host.hostsFileV6Key('{not json')).to.equal('');
+  });
+
+  it('should accept the JSON string form stored in redis', () => {
+    expect(Host.hostsFileV6Key('["2001:db8::1"]')).to.equal('2001:db8::1');
+  });
+
+  it('should drop link local and invalid addresses', () => {
+    // only these two affect the rendered hosts file
+    expect(Host.hostsFileV6Key(['fe80::1', '2001:db8::1', 'notanip', '2001:db8::2']))
+      .to.equal('2001:db8::1,2001:db8::2');
+    expect(Host.hostsFileV6Key(['fe80::1', 'fe80::2'])).to.equal('');
+  });
+
+  it('should not depend on the order of the addresses', () => {
+    expect(Host.hostsFileV6Key(['2001:db8::2', '2001:db8::1']))
+      .to.equal(Host.hostsFileV6Key(['2001:db8::1', '2001:db8::2']));
+  });
+});
+
+describe('Host.updateHostsFileIfChanged', function() {
+  const testMac = 'AA:BB:CC:DD:EE:01';
+  let host, calls, fail;
+
+  before(() => {
+    this.origIsFeatureOn = fc.isFeatureOn;
+    fc.isFeatureOn = (name) => name === 'local_domain' ? true : this.origIsFeatureOn(name);
+  });
+
+  after(() => {
+    fc.isFeatureOn = this.origIsFeatureOn;
+    delete Monitorable.instances[testMac];
+  });
+
+  beforeEach(() => {
+    fc.isFeatureOn = (name) => name === 'local_domain' ? true : this.origIsFeatureOn(name);
+    delete Monitorable.instances[testMac];
+    host = new Host({ mac: testMac, ipv4Addr: '192.168.1.2', localDomain: 'dev' });
+    calls = 0;
+    fail = false;
+    host.updateHostsFile = async () => {
+      calls++;
+      if (fail) throw new Error('write failed');
+    };
+  });
+
+  it('should refresh on the first run and then stay quiet', async() => {
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(1);
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(1);
+  });
+
+  it('should refresh when the ipv4 address changes', async() => {
+    await host.updateHostsFileIfChanged();
+    host.o.ipv4Addr = '192.168.1.3';
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(2);
+  });
+
+  it('should refresh on a routable ipv6 change but not on a link local one', async() => {
+    await host.updateHostsFileIfChanged();
+    host.ipv6Addr = ['2001:db8::1'];
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(2);
+
+    host.ipv6Addr = ['2001:db8::1', 'fe80::1'];
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(2);
+  });
+
+  it('should refresh when the local domain changes', async() => {
+    await host.updateHostsFileIfChanged();
+    host.o.localDomain = 'renamed';
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(2);
+
+    host.o.userLocalDomain = 'custom';
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(3);
+  });
+
+  it('should retry after a failed write', async() => {
+    fail = true;
+    await host.updateHostsFileIfChanged().catch(() => {});
+    expect(calls).to.equal(1);
+
+    // nothing changed, but the previous attempt did not go through
+    fail = false;
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(2);
+  });
+
+  it('should do nothing while local_domain is off', async() => {
+    fc.isFeatureOn = () => false;
+    await host.updateHostsFileIfChanged();
+    expect(calls).to.equal(0);
   });
 });

--- a/test/test_hosttool.js
+++ b/test/test_hosttool.js
@@ -89,3 +89,46 @@ describe.skip('Test Host Tool', () => {
     })
   })
 });
+
+describe('HostTool.removeDupIPv4FromMacEntry', function() {
+  const testMac = 'AA:BB:CC:DD:EE:02';
+  const testIp = '192.168.9.9';
+  const rclient = require('../util/redis_manager.js').getRedisClient();
+  const macKey = `host:mac:${testMac}`;
+
+  beforeEach(async() => {
+    await rclient.hmsetAsync(macKey, {
+      mac: testMac,
+      ipv4: testIp,
+      ipv4Addr: testIp,
+      localDomain: 'olddevice'
+    });
+  });
+
+  afterEach(async() => {
+    await rclient.unlinkAsync(macKey);
+    hostTool.invalidateMacEntryCache(testMac);
+  });
+
+  it('should drop both ipv4 keys and invalidate the cached entry', async() => {
+    // prime the LRU so we can tell the invalidation actually happened
+    const before = await hostTool.getMACEntry(testMac);
+    expect(before.ipv4Addr).to.equal(testIp);
+
+    await hostTool.removeDupIPv4FromMacEntry(testMac, testIp, 'AA:BB:CC:DD:EE:03');
+
+    const raw = await rclient.hgetallAsync(macKey);
+    expect(raw.ipv4).to.be.undefined;
+    expect(raw.ipv4Addr).to.be.undefined;
+    expect(raw.localDomain).to.equal('olddevice');
+
+    const after = await hostTool.getMACEntry(testMac);
+    expect(after.ipv4Addr).to.be.undefined;
+  });
+
+  it('should keep an ipv4 that belongs to a different address', async() => {
+    await hostTool.removeDupIPv4FromMacEntry(testMac, '192.168.9.10', 'AA:BB:CC:DD:EE:03');
+    const raw = await rclient.hgetallAsync(macKey);
+    expect(raw.ipv4Addr).to.equal(testIp);
+  });
+});


### PR DESCRIPTION
The per-device dnsmasq hosts file (`~/.firewalla/run/hosts/<MAC>`, served via `addn-hosts`) was only rewritten on `Scan:Done`, on `LocalDomainUpdate`, or by the 3-day inactivity expiry. NmapSensor's fast scan runs every 12 minutes, so after a device changed IP, `<name>.lan` kept resolving to the old address for up to that long — and in the takeover case, to an address that now belonged to a *different* device.

The same window applied to names: explicit renames emit `LocalDomainUpdate`, but `bname`-driven changes (bonjour / dhcp / ssdp / cloud discovering a better name) emit nothing.