### PR TITLE
keep deleted tags in rule scope when unenforcing

### DIFF
--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -1486,15 +1486,9 @@ class PolicyManager2 {
   async _applyBypass(bypassPolicy, action="enforce") {
     let {affectedPids, tag, pid, type, target, targets, scope, guids} = bypassPolicy;
     log.info(`${action} bypass policy ${pid} for affected policies ${affectedPids}, tag ${tag}`);
-    let { intfs, tags } = this.parseTags(tag)
-    // do not check for interface validity here as some of them might not be ready during enforcement. e.g. VPN
-    const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
-    tags = tags.filter((_, index) => tagExistenceChecks[index])
-    // invalid tag should not continue
-    if (tag && tag.length && !tags.length && !intfs.length) {
-      log.verbose(`Unknown policy tags format policy id: ${pid}, stop ${action} policy`);
-      return;
-    }
+    const ruleScope = await this.resolveRuleScope(tag, pid, action);
+    if (!ruleScope) return;
+    let { intfs, tags } = ruleScope;
 
     if (_.isEmpty(targets)) {
       targets = [target];
@@ -1715,6 +1709,22 @@ class PolicyManager2 {
     return { intfs, tags }
   }
 
+  // Resolve a rule's tag/interface scope. Returns null when the rule's tag field is
+  // non-empty but names nothing usable, meaning the caller should stop.
+  async resolveRuleScope(tag, pid, action) {
+    let { intfs, tags } = this.parseTags(tag)
+    // do not check for interface validity here as some of them might not be ready during enforcement. e.g. VPN
+    const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
+    tags = tags.filter((_, index) => tagExistenceChecks[index])
+    // invalid tag should not continue
+    if (tag && tag.length && !tags.length && !intfs.length) {
+      const logFn = action === "enforce" ? log.verbose : log.warn;
+      logFn(`Unknown policy tags format policy id: ${pid}, stop ${action} policy`);
+      return null;
+    }
+    return { intfs, tags };
+  }
+
   async _enforce(policy) {
     log.info(`Enforce policy ${policy.pid}:`, policy.action || "block", policy.type, policy.target, policy.scope, policy.tag);
 
@@ -1752,15 +1762,9 @@ class PolicyManager2 {
     }
 
 
-    let { intfs, tags } = this.parseTags(tag)
-    // do not check for interface validity here as some of them might not be ready during enforcement. e.g. VPN
-    const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
-    tags = tags.filter((_, index) => tagExistenceChecks[index])
-    // invalid tag should not continue
-    if (tag && tag.length && !tags.length && !intfs.length) {
-      log.verbose(`Unknown policy tags format policy id: ${pid}, stop enforce policy`);
-      return;
-    }
+    const ruleScope = await this.resolveRuleScope(tag, pid, "enforce");
+    if (!ruleScope) return;
+    let { intfs, tags } = ruleScope;
 
     const security = policy.isSecurityBlockPolicy();
     const subPrio = this._getRuleSubPriority(type);
@@ -2448,15 +2452,9 @@ class PolicyManager2 {
       return this._unenforceBypass(policy);
     }
 
-    let { intfs, tags } = this.parseTags(tag)
-    // do not check for interface validity here as some of them might not be ready during enforcement. e.g. VPN
-    const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
-    tags = tags.filter((_, index) => tagExistenceChecks[index])
-    // invalid tag should not continue
-    if (tag && tag.length && !tags.length && !intfs.length) {
-      log.error(`Unknown policy tags format policy id: ${pid}, stop unenforce policy`);
-      return;
-    }
+    const ruleScope = await this.resolveRuleScope(tag, pid, "unenforce");
+    if (!ruleScope) return;
+    let { intfs, tags } = ruleScope;
 
     const devOpts = { tags, intfs, scope, guids };
 

--- a/alarm/PolicyManager2.js
+++ b/alarm/PolicyManager2.js
@@ -1711,11 +1711,20 @@ class PolicyManager2 {
 
   // Resolve a rule's tag/interface scope. Returns null when the rule's tag field is
   // non-empty but names nothing usable, meaning the caller should stop.
+  //
+  // The existence filter applies to enforcement only. On enforce, a tag that no longer
+  // exists must be dropped: Block.setupTagsRules() would call ensureCreateEnforcementEnv()
+  // and create ipsets nothing will ever clean up. On unenforce the opposite holds -- the
+  // tag being gone is the reason teardown must run, and the uid has to survive into
+  // commonOptions.tags or the -D commands won't match what enforcement installed,
+  // stranding FW_DISTURB_QOS_* jumps that pin the tag's ipsets at References != 0.
   async resolveRuleScope(tag, pid, action) {
     let { intfs, tags } = this.parseTags(tag)
     // do not check for interface validity here as some of them might not be ready during enforcement. e.g. VPN
-    const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
-    tags = tags.filter((_, index) => tagExistenceChecks[index])
+    if (action === "enforce") {
+      const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
+      tags = tags.filter((_, index) => tagExistenceChecks[index])
+    }
     // invalid tag should not continue
     if (tag && tag.length && !tags.length && !intfs.length) {
       const logFn = action === "enforce" ? log.verbose : log.warn;

--- a/test/test_policymngr2.js
+++ b/test/test_policymngr2.js
@@ -26,6 +26,8 @@ const domainBlock = require('../control/DomainBlock.js');
 const cloudcache = require('../extension/cloudcache/cloudcache');
 const DNSMASQ = require('../extension/dnsmasq/dnsmasq.js');
 const dnsmasq = new DNSMASQ();
+const Bypass = require('../control/Bypass.js');
+const Tag = require('../net2/Tag.js');
 
 const log = require('../net2/logger.js')(__filename);
 
@@ -366,5 +368,232 @@ describe('Test deleteTagRelatedPolicies unenforce synchronization', function() {
     // first call = failed attempt with the reduced tag list, second = rollback restoring the old (full) tag list
     expect(enforceCalls.length).to.equal(2);
     expect(enforceCalls[1]).to.deep.equal([`tag:${uid}`, 'otherTag']);
+  });
+});
+
+// The suite above stubs pm2.unenforce/enforceOnQueue, so it never reaches the real
+// _unenforce()/_enforce()/_applyBypass() and can't see resolveRuleScope() or the guard it
+// replaced. These tests call the real functions and stub only the outermost iptables/ipset
+// seam (__applyRules / Bypass.bypassIptablesRules), matching test_bypass.js's convention of
+// stubbing Tag.ensureCreateEnforcementEnv where a case still reaches it directly.
+describe('Test _unenforce/_enforce/_applyBypass teardown when a rule\'s tag no longer exists', function() {
+  this.timeout(5000);
+
+  it('_unenforce() keeps a dead tag\'s uid in scope so teardown can still match enforcement', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeadTagOnly';
+    const rule = new Policy({ pid: 'testDeadTagOnlyPid', type: 'intranet', action: 'block', tag: [`tag:${uid}`] });
+
+    let applyRulesOptions = null;
+    const origApplyRules = pm2.__applyRules;
+    const origRemoveActivatedTime = pm2._removeActivatedTime;
+    pm2.__applyRules = async (options) => { applyRulesOptions = options; };
+    pm2._removeActivatedTime = async () => {};
+
+    try {
+      await pm2._unenforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._removeActivatedTime = origRemoveActivatedTime;
+    }
+
+    expect(applyRulesOptions).to.not.be.null;
+    expect(applyRulesOptions.tags).to.deep.equal([uid]);
+  });
+
+  it('_unenforce() keeps a dead tag\'s uid in scope alongside an interface', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeadTagWithIntf';
+    const intfUuid = 'testIntfUuid';
+    const rule = new Policy({ pid: 'testDeadTagWithIntfPid', type: 'intranet', action: 'block', tag: [`tag:${uid}`, `intf:${intfUuid}`] });
+
+    let applyRulesOptions = null;
+    const origApplyRules = pm2.__applyRules;
+    const origRemoveActivatedTime = pm2._removeActivatedTime;
+    pm2.__applyRules = async (options) => { applyRulesOptions = options; };
+    pm2._removeActivatedTime = async () => {};
+
+    try {
+      await pm2._unenforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._removeActivatedTime = origRemoveActivatedTime;
+    }
+
+    // before the fix, the guard couldn't fire here (an interface is present), but the
+    // unconditional existence filter still silently dropped the dead tag from `tags`
+    expect(applyRulesOptions).to.not.be.null;
+    expect(applyRulesOptions.tags).to.deep.equal([uid]);
+    expect(applyRulesOptions.intfs).to.deep.equal([intfUuid]);
+  });
+
+  it('_unenforce() keeps a dead tag alongside a live tag (the reenforce path)', async () => {
+    const pm2 = new PolicyManager2();
+    const deadUid = 'testDeadTagWithLive';
+    const liveUid = 'testLiveTagWithDead';
+    const rule = new Policy({ pid: 'testDeadTagWithLivePid', type: 'intranet', action: 'block', tag: [`tag:${deadUid}`, `tag:${liveUid}`] });
+
+    let applyRulesOptions = null;
+    const origApplyRules = pm2.__applyRules;
+    const origRemoveActivatedTime = pm2._removeActivatedTime;
+    pm2.__applyRules = async (options) => { applyRulesOptions = options; };
+    pm2._removeActivatedTime = async () => {};
+
+    try {
+      await pm2._unenforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._removeActivatedTime = origRemoveActivatedTime;
+    }
+
+    // before the fix, deleteTagRelatedPolicies() routes this rule shape through 'reenforce',
+    // which unenforces the old policy carrying both uids; the existence filter silently
+    // dropped the dead one from `tags` even though the guard never fired
+    expect(applyRulesOptions).to.not.be.null;
+    expect(applyRulesOptions.tags).to.deep.equal([deadUid, liveUid]);
+  });
+
+  it('_unenforce() on the reported disturb/qos shape keeps the tag uid and the bypass chain name', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeadTagDisturb';
+    const rule = new Policy({
+      pid: 'testDeadTagDisturbPid', type: 'intranet', action: 'disturb', tag: [`tag:${uid}`],
+      increaseLatency: 100, dropPacketRate: 10
+    });
+
+    let applyRulesOptions = null;
+    const origApplyRules = pm2.__applyRules;
+    const origRemoveActivatedTime = pm2._removeActivatedTime;
+    pm2.__applyRules = async (options) => { applyRulesOptions = options; };
+    pm2._removeActivatedTime = async () => {};
+
+    try {
+      await pm2._unenforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._removeActivatedTime = origRemoveActivatedTime;
+    }
+
+    // this is the exact options tuple that, before the fix, produced the leaked
+    // FW_DISTURB_QOS_* jumps: a tag-scoped disturb rule rewritten to action 'qos'
+    expect(applyRulesOptions).to.not.be.null;
+    expect(applyRulesOptions.tags).to.deep.equal([uid]);
+    expect(applyRulesOptions.byPassChain).to.equal(`FW_${rule.pid}_BYPASS`);
+  });
+
+  it('_unenforce() on a rule whose target is the deleted tag itself is unaffected by the guard', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeletedTagAsTarget';
+    // deleteTagRelatedPolicies() reaches this shape via its rule.type === "tag" branch;
+    // rule.tag is empty here so the guard (which checks `tag && tag.length`) never applied,
+    // with or without the fix -- this just documents that this shape was never at risk
+    const rule = new Policy({ pid: 'testDeletedTagAsTargetPid', type: 'tag', action: 'block', target: uid });
+
+    let applyRulesOptions = null;
+    const origApplyRules = pm2.__applyRules;
+    const origRemoveActivatedTime = pm2._removeActivatedTime;
+    const origTagEnsure = Tag.ensureCreateEnforcementEnv;
+    pm2.__applyRules = async (options) => { applyRulesOptions = options; };
+    pm2._removeActivatedTime = async () => {};
+    Tag.ensureCreateEnforcementEnv = async () => {};
+
+    try {
+      await pm2._unenforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._removeActivatedTime = origRemoveActivatedTime;
+      Tag.ensureCreateEnforcementEnv = origTagEnsure;
+    }
+
+    expect(applyRulesOptions).to.not.be.null;
+    expect(applyRulesOptions.tags).to.deep.equal([]);
+  });
+
+  it('_enforce() drops a dead tag and stops before __applyRules', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeadTagEnforce';
+    const rule = new Policy({ pid: 'testDeadTagEnforcePid', type: 'intranet', action: 'block', tag: [`tag:${uid}`] });
+
+    let applyRulesCalled = false;
+    const origApplyRules = pm2.__applyRules;
+    const origRefreshActivatedTime = pm2._refreshActivatedTime;
+    pm2.__applyRules = async () => { applyRulesCalled = true; };
+    pm2._refreshActivatedTime = async () => {};
+
+    try {
+      await pm2._enforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._refreshActivatedTime = origRefreshActivatedTime;
+    }
+
+    // the enforce-side guard is unchanged: a tag that no longer exists must still be
+    // dropped, or Block.setupTagsRules would create ipsets nothing will ever clean up
+    expect(applyRulesCalled).to.be.false;
+  });
+
+  it('_unenforce() with a malformed (non-prefixed) tag field still stops before __applyRules', async () => {
+    const pm2 = new PolicyManager2();
+    const rule = new Policy({ pid: 'testMalformedTagPid', type: 'intranet', action: 'block', tag: ['garbage'] });
+
+    let applyRulesCalled = false;
+    const origApplyRules = pm2.__applyRules;
+    const origRemoveActivatedTime = pm2._removeActivatedTime;
+    pm2.__applyRules = async () => { applyRulesCalled = true; };
+    pm2._removeActivatedTime = async () => {};
+
+    try {
+      await pm2._unenforce(rule);
+    } finally {
+      pm2.__applyRules = origApplyRules;
+      pm2._removeActivatedTime = origRemoveActivatedTime;
+    }
+
+    // the format guard is untouched by the fix: a tag field that names nothing
+    // recognizable still has nothing tag-scoped to tear down
+    expect(applyRulesCalled).to.be.false;
+  });
+
+  it('_applyBypass(policy, "unenforce") keeps a dead tag\'s uid in scope', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeadTagBypassUnenforce';
+    const bypassPolicy = new Policy({
+      pid: 'testDeadTagBypassUnenforcePid', type: 'country', target: 'US',
+      tag: [`tag:${uid}`], affectedPids: ['1']
+    });
+
+    let bypassOptions = null;
+    const origBypassIptablesRules = Bypass.bypassIptablesRules;
+    Bypass.bypassIptablesRules = async (options) => { bypassOptions = options; };
+
+    try {
+      await pm2._applyBypass(bypassPolicy, 'unenforce');
+    } finally {
+      Bypass.bypassIptablesRules = origBypassIptablesRules;
+    }
+
+    expect(bypassOptions).to.not.be.null;
+    expect(bypassOptions.tags).to.deep.equal([uid]);
+  });
+
+  it('_applyBypass(policy, "enforce") drops a dead tag and stops before bypassIptablesRules', async () => {
+    const pm2 = new PolicyManager2();
+    const uid = 'testDeadTagBypassEnforce';
+    const bypassPolicy = new Policy({
+      pid: 'testDeadTagBypassEnforcePid', type: 'country', target: 'US',
+      tag: [`tag:${uid}`], affectedPids: ['1']
+    });
+
+    let bypassCalled = false;
+    const origBypassIptablesRules = Bypass.bypassIptablesRules;
+    Bypass.bypassIptablesRules = async () => { bypassCalled = true; };
+
+    try {
+      await pm2._applyBypass(bypassPolicy, 'enforce');
+    } finally {
+      Bypass.bypassIptablesRules = origBypassIptablesRules;
+    }
+
+    expect(bypassCalled).to.be.false;
   });
 });


### PR DESCRIPTION
Fixes firewalla/firecommit#9522

## What changed

`PolicyManager2` no longer filters non-existent tags out of a rule's scope when **unenforcing**. The existence filter is now applied on the **enforce** path only.

Two commits:

1. `6383c29cb` — **refactor:** extract the three copy-pasted `parseTags` + tag-existence-filter + `Unknown policy tags format` guard blocks (`_enforce`, `_unenforce`, `_applyBypass`) into one `resolveRuleScope(tag, pid, action)` helper. No behaviour change.
2. `61e62d559` — **fix:** gate the existence filter on `action === "enforce"` inside that helper.

The behavioural diff is one `if`:

```diff
   async resolveRuleScope(tag, pid, action) {
     let { intfs, tags } = this.parseTags(tag)
-    const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
-    tags = tags.filter((_, index) => tagExistenceChecks[index])
+    if (action === "enforce") {
+      const tagExistenceChecks = await Promise.all(tags.map(t => tagManager.tagUidExists(t)))
+      tags = tags.filter((_, index) => tagExistenceChecks[index])
+    }
     // invalid tag should not continue
     if (tag && tag.length && !tags.length && !intfs.length) {
```

## Root cause

The reported defect is real, but the early return the issue focuses on is only the loudest of three failure shapes. The actual culprit is **the filter**, not the guard.

`tags` is the only thing that carries a tag uid into teardown: `commonOptions` → `__applyRules` → `_applyRules` → `Block.setupTagsRules`, where `control/Block.js:1092` flips the operator to `-D` and `:1112-1114,1149-1150` build the `FW_DISTURB_QOS_{DEV,NET}_G` rules from `c_tag_<uid>_dev_set` / `_net_set`. A `-D` is the `-A` with the operator flipped, so **the uid must be present in `tags` or the delete cannot match what enforcement installed.** Filtering a deleted tag out of `tags` on the destroy path is wrong by construction.

| rule shape | guard fires? | result |
|---|---|---|
| dead tag only, no interface | yes | whole teardown body skipped — the reported case, with the `Unknown policy tags format` log line |
| dead tag **+** interface | no (`!intfs.length` fails) | `tags` empty → `_applyRules` skips `setupTagsRules` → tag-scoped `-D` never issued. **Silent, no log line.** |
| dead tag + live tag | no | routed to `reenforce`, which unenforces `oldPolicy` carrying both tags; the dead one is filtered out → its `-D` never issued. **Silent.** |

This is why the issue's fallback proposal — scope the *guard* to `action === 'enforce'` — is insufficient: it leaves the filter in place, and rows 2 and 3 keep leaking with no log line at all.

The leftover `FW_DISTURB_QOS_* -j FW_<pid>_BYPASS` rules hold `c_tag_<uid>_dev_set` at `References != 0`, and `Ipset.destroy()` (`net2/Ipset.js:158-161`, guarded by `isReferenced` at `:79-89`) is a silent no-op on referenced sets. `Tag.destroyEnv()` calls `deleteTagRelatedPolicies()` at `net2/Tag.js:164` and only reaches its `Ipset.destroy` calls at `:187-192`, so running teardown first is exactly what unblocks the destroys. `removeBypassChainForPolicy()` cannot rescue this: `Bypass.removeBypassChain` flushes with `-F` but its `-X` fails while jumps remain, and it clears its `initializedBypassChain` bookkeeping unconditionally so it is never retried. The issue's read of that part is correct.

## Design decisions

**The guard stays; only the filter moves.** On unenforce the check reverts to its pre-2021 meaning — a *format* check. If `rule.tag` is non-empty but nothing parses, there is genuinely nothing tag-scoped to tear down, and stopping is better than falling through to `setupGlobalRules`, which would issue global `-D` for a pid that was never enforced globally. This is strictly better than the reporter's "drop the guard entirely".

**Refactor first, in its own commit.** The same nine-line block was copy-pasted three times, differing only in a log level and an interpolated verb — and that duplication *is* the bug's delivery mechanism. The 2021 refactor changed one helper and all three sites silently inherited a new meaning. The fix is "these three sites must now differ on exactly one axis"; hand-editing three near-copies to encode that is how the next drift gets introduced.

**`_applyBypass` gets the same fix, for free.** It already receives `action` as `"enforce"`/`"unenforce"` and passes its own parameter straight through, so both legs get correct behaviour with zero additional code. `control/Bypass.js:190` picks `-D` for `action === "unenforce"` and builds per-tag `RETURN` rules from the same `devSet`/`netSet`, so an emptied `tags` breaks bypass teardown identically. It is not on the reported reproduction path (`deleteTagRelatedPolicies` iterates `loadActivePoliciesAsync`, never `loadActiveBypassPoliciesAsync`), but it is the same wrongness.

**No downstream tolerance work was needed.** Verified that no file on the teardown path (`control/Block.js`, `control/Bypass.js`, `control/DomainBlock.js`, `extension/dnsmasq/dnsmasq.js`, `control/CategoryUpdater.js`) references `tagManager` or dereferences a live `Tag` object — every consumer treats the uid as an opaque string used to build an ipset name or a dnsmasq file path.